### PR TITLE
release: v0.7.1 — security hardening + README refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.7.1 - 2026-03-06
+
+### Changed
+- README updated with v0.7 feature highlights and consolidated v0.6 section
+- All GitHub Actions pinned to commit SHAs (not tag objects) for OpenSSF compliance
+- All pip CI dependencies hash-pinned with `--require-hashes`
+- Top-level `permissions: read-all` on all workflows
+
+### Added
+- `SECURITY.md` with vulnerability disclosure policy and timeline
+- `.github/dependabot.yml` for automated pip + actions updates
+- `publish.yml` workflow for trusted PyPI publishing via OIDC (tag-triggered)
+- `requirements/test.txt` and `requirements/publish.txt` with SHA-256 hashes
+- GitHub Releases for v0.5.0, v0.6.0, v0.6.4, v0.7.0
+- Branch protection on `main` (force push, deletion, status checks)
+
+### Fixed
+- Scorecard action SHA was tag object, not commit — caused imposter commit failure
+- `test_auto_tag_handles_ai_tool_unavailable_file_not_found` missing `{ticket}` placeholder — passed locally (claude fallback) but failed in CI
+
 ## v0.7.0 - 2026-03-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/fraction12/agentplan"><img src="https://img.shields.io/github/stars/fraction12/agentplan" alt="GitHub stars"></a>
 </p>
 
-<p align="center"><em>agentplan is used in production AI agent pipelines. <a href="https://pypistats.org/packages/agentplan">Downloads trending on PyPI.</a></em></p>
+<p align="center"><em>Zero dependencies. 242 tests. Used in production AI agent pipelines. <a href="https://pypistats.org/packages/agentplan">Downloads trending on PyPI.</a></em></p>
 
 <p align="center">
   <a href="#marketplace--actions">Marketplace & Actions</a> ·
@@ -87,22 +87,23 @@ Policy and support links:
 
 `agentplan` actions do not require any hard-coded third-party secrets by default.
 
+## What's New in v0.7
+
+- **GitHub Marketplace Actions** — `actions/setup` and `actions/run-chain` for CI/CD integration
+- **CI/Headless Mode** — Run chains in GitHub Actions with `AGENTPLAN_CI=1`
+- **Issue Import** — `agentplan issue import` pulls labeled GitHub issues into tickets
+- **Artifact Tracking** — Runtime artifact integrity verification
+- **Security Hardening** — OpenSSF Scorecard compliance, hash-pinned dependencies, trusted PyPI publishing, branch protection, Dependabot
+- **242 tests** covering all features
+
 ## What's New in v0.6
 
 - **Project Directories** — `agentplan create --dir ~/path` links a project to a codebase
-- **`.agentplan.md` Context Files** — per-project context injected into every agent turn. First agent auto-generates it by scanning the project.
-- **`agentplan context`** — view or regenerate a project's context file
-- **Dashboard Context Panel** — collapsible panel showing the context file on each project page
-
-## What's New in v0.5
-
-- **Roles & Agent Registry** — Define roles (coding, research, writing), register agents with command templates, and route tickets to the right agent automatically
-- **Event Hooks** — Fire webhooks, commands, or agent chains when tickets complete
-- **Stale Claim Handling** — Claim timeouts, automatic reaping of expired claims
-- **Expanded State Machine** — `blocked`, `failed`, `needs-review` states with validated transitions
-- **Dashboard Control Plane** — Start Work / Stop buttons, real-time progress, Agents management page, review panel for failed tickets
-- **Auto-Detection** — `agentplan init` scans for installed AI tools (Claude, Codex, Aider, Cursor, OpenClaw)
-- **186 tests** covering all features
+- **Agent-Powered Context** — context generation via writer agent with structured investigation prompts
+- **`.agentplan.md` Context Files** — per-project context injected into every agent turn
+- **Dashboard Refactor** — proper Flask templates + static assets, context generation UI with polling
+- **Directory Guards** — hard-error on missing project dirs, editable directory field in dashboard
+- **Chain Reliability** — re-entry guards, state rollback, zombie PID detection, spawn failure handling
 
 ## Quickstart
 

--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -57,7 +57,7 @@ from agentplan.db import (
     is_valid_iso_local_timestamp,
 )
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 # ---------------------------------------------------------------------------
 # Input validation limits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentplan"
-version = "0.7.0"
+version = "0.7.1"
 description = "A shared to-do list for AI agents. Dependency-aware task queue, zero dependencies, pure Python."
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Changes
- OpenSSF Scorecard hardening (3.6 → 6.8+)
- README updated with v0.7 feature highlights
- Trusted PyPI publishing pipeline
- Hash-pinned CI dependencies
- Test fix for CI-only auto-tag failure

**After merge:** Tag `v0.7.1` to trigger the publish workflow and test the PyPI pipeline.