### PR TITLE
[codex] dashboard field editor

### DIFF
--- a/agentplan/dashboard/static/project.js
+++ b/agentplan/dashboard/static/project.js
@@ -32,6 +32,33 @@
   const panelContent = document.getElementById("ticket-panel-content");
   const projectSlug = cfg.projectSlug;
   let dependencyOptionsCache = null;
+  const FIELD_EDITOR_CONFIG = {
+    title: {
+      type: "input",
+      title: "Edit title",
+      label: "Title",
+      help: "Update the ticket title.",
+      emptyMessage: "Title cannot be empty.",
+      normalize: (value) => String(value || "").trim(),
+    },
+    description: {
+      type: "textarea",
+      title: "Edit description",
+      label: "Description",
+      help: "Update the ticket description.",
+      normalize: (value) => String(value || "").trim(),
+    },
+    priority: {
+      type: "select",
+      title: "Edit priority",
+      label: "Priority",
+      help: "Choose one of the supported priority levels.",
+      normalize: (value) => String(value || "none").trim().toLowerCase(),
+      isValid: (value) => ["high", "medium", "low", "none"].includes(value),
+      emptyMessage: "Choose a valid priority.",
+    },
+  };
+  let activeFieldEdit = null;
 
   function renderList(items, emptyText, variant = "plain", ticketNum = "") {
     if (!items || items.length === 0) return `<p class="panel-muted">${esc(emptyText)}</p>`;
@@ -152,6 +179,86 @@
       renderPanel(data);
     } catch (error) {
       panelContent.innerHTML = `<section class="panel-block"><p class="panel-muted">Failed to load ticket details (${esc(error.message)}).</p></section>`;
+    }
+  }
+
+  const fieldDialog = document.getElementById("ticket-field-dialog");
+  const fieldForm = document.getElementById("ticket-field-form");
+  const fieldDialogTitle = document.getElementById("ticket-field-dialog-title");
+  const fieldDialogHelp = document.getElementById("ticket-field-dialog-help");
+  const fieldInputRow = document.getElementById("ticket-field-input-row");
+  const fieldInputLabel = document.getElementById("ticket-field-input-label");
+  const fieldInput = document.getElementById("ticket-field-input");
+  const fieldTextareaRow = document.getElementById("ticket-field-textarea-row");
+  const fieldTextareaLabel = document.getElementById("ticket-field-textarea-label");
+  const fieldTextarea = document.getElementById("ticket-field-textarea");
+  const fieldSelectRow = document.getElementById("ticket-field-select-row");
+  const fieldSelectLabel = document.getElementById("ticket-field-select-label");
+  const fieldSelect = document.getElementById("ticket-field-select");
+  const fieldError = document.getElementById("ticket-field-error");
+  const fieldCancelBtn = document.getElementById("ticket-field-cancel");
+  const fieldSaveBtn = document.getElementById("ticket-field-save");
+
+  function clearFieldEditorError() {
+    if (!fieldError) return;
+    fieldError.hidden = true;
+    fieldError.textContent = "";
+  }
+
+  function setFieldEditorError(message) {
+    if (!fieldError) return;
+    fieldError.textContent = message;
+    fieldError.hidden = false;
+  }
+
+  function activeFieldControl() {
+    if (!activeFieldEdit) return null;
+    const editor = FIELD_EDITOR_CONFIG[activeFieldEdit.field];
+    if (!editor) return null;
+    if (editor.type === "textarea") return fieldTextarea;
+    if (editor.type === "select") return fieldSelect;
+    return fieldInput;
+  }
+
+  function setActiveFieldValue(value) {
+    const control = activeFieldControl();
+    if (!control) return;
+    control.value = String(value ?? "");
+  }
+
+  function getActiveFieldValue() {
+    const control = activeFieldControl();
+    if (!control) return "";
+    return control.value;
+  }
+
+  function closeFieldEditor() {
+    activeFieldEdit = null;
+    clearFieldEditorError();
+    if (fieldForm) fieldForm.reset();
+    if (fieldSaveBtn) fieldSaveBtn.disabled = false;
+    if (fieldDialog?.open) fieldDialog.close();
+  }
+
+  function openFieldEditor(field, ticketNum, currentValue) {
+    const editor = FIELD_EDITOR_CONFIG[field];
+    if (!editor || !fieldDialog) return;
+    activeFieldEdit = { field, ticketNum, originalValue: editor.normalize ? editor.normalize(currentValue) : String(currentValue ?? "") };
+    clearFieldEditorError();
+    if (fieldDialogTitle) fieldDialogTitle.textContent = editor.title;
+    if (fieldDialogHelp) fieldDialogHelp.textContent = editor.help;
+    if (fieldInputLabel) fieldInputLabel.textContent = editor.label;
+    if (fieldTextareaLabel) fieldTextareaLabel.textContent = editor.label;
+    if (fieldSelectLabel) fieldSelectLabel.textContent = editor.label;
+    if (fieldInputRow) fieldInputRow.hidden = editor.type !== "input";
+    if (fieldTextareaRow) fieldTextareaRow.hidden = editor.type !== "textarea";
+    if (fieldSelectRow) fieldSelectRow.hidden = editor.type !== "select";
+    setActiveFieldValue(activeFieldEdit.originalValue);
+    fieldDialog.showModal();
+    const control = activeFieldControl();
+    if (control) {
+      control.focus();
+      if (typeof control.select === "function" && editor.type !== "select") control.select();
     }
   }
 
@@ -426,6 +533,7 @@
   closeBtn.addEventListener("click", closePanel);
   backdrop.addEventListener("click", closePanel);
   document.addEventListener("keydown", (event) => {
+    if (fieldDialog?.open) return;
     if (event.key === "Escape" && panel.classList.contains("is-open")) closePanel();
   });
 
@@ -881,23 +989,64 @@
     const field = btn.dataset.editField;
     const ticketNum = btn.dataset.editNum;
     const currentValue = _panelData[field] || "";
-    const newValue = prompt(`Edit ${field}:`, currentValue);
-    if (newValue === null || newValue === currentValue) return;
-    try {
-      const resp = await fetch(`/api/ticket/${encodeURIComponent(projectSlug)}/${ticketNum}/edit`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ [field]: newValue }),
-      });
-      const data = await resp.json();
-      if (data.ok) {
+    openFieldEditor(field, ticketNum, currentValue);
+  });
+
+  if (fieldCancelBtn) {
+    fieldCancelBtn.addEventListener("click", closeFieldEditor);
+  }
+
+  if (fieldDialog) {
+    fieldDialog.addEventListener("click", (event) => {
+      if (event.target === fieldDialog) closeFieldEditor();
+    });
+    fieldDialog.addEventListener("close", () => {
+      activeFieldEdit = null;
+      clearFieldEditorError();
+      if (fieldSaveBtn) fieldSaveBtn.disabled = false;
+    });
+  }
+
+  if (fieldForm) {
+    fieldForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!activeFieldEdit) return;
+      const editor = FIELD_EDITOR_CONFIG[activeFieldEdit.field];
+      if (!editor) return;
+      const normalized = editor.normalize ? editor.normalize(getActiveFieldValue()) : getActiveFieldValue();
+      if (editor.emptyMessage && !normalized) {
+        setFieldEditorError(editor.emptyMessage);
+        activeFieldControl()?.focus();
+        return;
+      }
+      if (editor.isValid && !editor.isValid(normalized)) {
+        setFieldEditorError(editor.emptyMessage || "Enter a valid value.");
+        activeFieldControl()?.focus();
+        return;
+      }
+      if (normalized === activeFieldEdit.originalValue) {
+        closeFieldEditor();
+        return;
+      }
+      if (fieldSaveBtn) fieldSaveBtn.disabled = true;
+      clearFieldEditorError();
+      try {
+        const ticketNum = activeFieldEdit.ticketNum;
+        const field = activeFieldEdit.field;
+        const resp = await fetch(`/api/ticket/${encodeURIComponent(projectSlug)}/${ticketNum}/edit`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ [field]: normalized }),
+        });
+        const data = await resp.json().catch(() => null);
+        if (!resp.ok) throw new Error((data && data.error) || `HTTP ${resp.status}`);
+        closeFieldEditor();
         showToast(`Ticket #${ticketNum} updated`);
         loadTicket(ticketNum);
-      } else {
-        showToast(data.error || "Failed to update", "error");
+      } catch (err) {
+        if (fieldSaveBtn) fieldSaveBtn.disabled = false;
+        setFieldEditorError(err.message || "Failed to update ticket.");
       }
-    } catch (err) {
-      showToast("Network error", "error");
-    }
-  });
+    });
+  }
 })();

--- a/agentplan/dashboard/static/style.css
+++ b/agentplan/dashboard/static/style.css
@@ -604,3 +604,31 @@ h1 { font-family: var(--font-heading); }
   background: rgba(255,255,255,0.1);
   color: #fff;
 }
+.ticket-field-dialog {
+  width: min(32rem, calc(100vw - 2rem));
+}
+.ticket-field-help {
+  margin: 0.25rem 0 1rem;
+  color: rgba(255,255,255,0.64);
+  font-size: 0.9rem;
+}
+.ticket-field-row[hidden] {
+  display: none;
+}
+.ticket-field-row span {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: rgba(255,255,255,0.8);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.ticket-field-dialog textarea {
+  min-height: 8rem;
+  resize: vertical;
+}
+.ticket-field-error {
+  margin: 0.9rem 0 0;
+  color: #ff8e8e;
+  font-size: 0.9rem;
+}

--- a/agentplan/dashboard/templates/project.html
+++ b/agentplan/dashboard/templates/project.html
@@ -95,6 +95,35 @@
   </form>
 </dialog>
 
+<dialog id="ticket-field-dialog" class="ticket-dialog ticket-field-dialog">
+  <form id="ticket-field-form" method="dialog">
+    <h3 id="ticket-field-dialog-title">Edit field</h3>
+    <p id="ticket-field-dialog-help" class="ticket-field-help">Update the selected ticket field.</p>
+    <label id="ticket-field-input-row" class="ticket-field-row" hidden>
+      <span id="ticket-field-input-label">Value</span>
+      <input id="ticket-field-input" type="text" name="value" maxlength="255" autocomplete="off">
+    </label>
+    <label id="ticket-field-textarea-row" class="ticket-field-row" hidden>
+      <span id="ticket-field-textarea-label">Value</span>
+      <textarea id="ticket-field-textarea" name="value_multiline" rows="5" maxlength="4000"></textarea>
+    </label>
+    <label id="ticket-field-select-row" class="ticket-field-row" hidden>
+      <span id="ticket-field-select-label">Value</span>
+      <select id="ticket-field-select" name="value_select">
+        <option value="none">None</option>
+        <option value="high">High</option>
+        <option value="medium">Medium</option>
+        <option value="low">Low</option>
+      </select>
+    </label>
+    <p id="ticket-field-error" class="ticket-field-error" hidden></p>
+    <div class="dialog-actions">
+      <button type="button" class="btn" id="ticket-field-cancel">Cancel</button>
+      <button type="submit" class="btn btn-primary" id="ticket-field-save">Save</button>
+    </div>
+  </form>
+</dialog>
+
 <details class="context-panel" aria-label="project context">
   <summary>
     <span>Project Context</span>

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -1557,6 +1557,23 @@ def test_dashboard_project_detail_includes_editable_directory_field():
     assert 'id="project-dir-input"' in body
 
 
+def test_dashboard_project_detail_includes_ticket_field_edit_dialog():
+    from agentplan.dashboard import app
+
+    cli("create", "Web Ticket Field Dialog")
+
+    client = app.test_client()
+    resp = client.get("/project/web-ticket-field-dialog")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'id="ticket-field-dialog"' in body
+    assert 'id="ticket-field-form"' in body
+    assert 'id="ticket-field-input"' in body
+    assert 'id="ticket-field-textarea"' in body
+    assert 'id="ticket-field-select"' in body
+    assert 'id="ticket-field-save"' in body
+
+
 def test_dashboard_project_detail_links_to_ticket_detail_view():
     from agentplan.dashboard import app
 
@@ -2545,6 +2562,40 @@ def test_dashboard_project_detail_script_includes_dependency_and_log_controls():
     assert '/tickets-list' in project_js
     assert 'form[data-ticket-log-form][data-ticket-num]' in project_js
     assert '/log`' in project_js
+
+
+def test_dashboard_ticket_edit_endpoint_updates_supported_fields():
+    from agentplan.dashboard import create_app
+
+    cli("create", "Ticket Edit API")
+    cli("ticket", "add", "ticket-edit-api", "Original title", "--desc", "Original description")
+
+    test_app = create_app()
+    client = test_app.test_client()
+    resp = client.post(
+        "/api/ticket/ticket-edit-api/1/edit",
+        json={"title": "Updated title", "description": "Updated description", "priority": "high"},
+        headers={"Origin": "http://localhost"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}
+
+    conn = agentplan.get_connection("/tmp/test_agentplan.db")
+    row = conn.execute(
+        "SELECT title, description, priority FROM tickets WHERE project_id=1 AND num=1"
+    ).fetchone()
+    conn.close()
+    assert row["title"] == "Updated title"
+    assert row["description"] == "Updated description"
+    assert row["priority"] == "high"
+
+
+def test_dashboard_project_detail_script_uses_real_ticket_field_editor():
+    project_js = Path("agentplan/dashboard/static/project.js").read_text(encoding="utf-8")
+    assert "FIELD_EDITOR_CONFIG" in project_js
+    assert "ticket-field-dialog" in project_js
+    assert "prompt(" not in project_js
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The dashboard ticket detail panel was still using the browser's native `prompt()` flow for ticket field edits. That created the exact bad interaction shown in UAT: blocking browser chrome, no room for multiline editing, and no constrained control for priority values. This change replaces that with a real dashboard-native edit dialog.

## Problem
On the project page, the title, description, and priority edit buttons in the ticket side panel all routed through a single `prompt()` handler. That meant users were taken out of the dashboard interaction model whenever they tried to edit a field, and the prompt experience was especially poor for long descriptions and invalid priority input.

## Root Cause
The project page had one generic click handler in `agentplan/dashboard/static/project.js` that called `prompt()` for every `data-edit-field` action. There was no reusable field editor component in the template, so the browser dialog became the fallback UI for all ticket field edits.

## Fix
This PR adds a reusable ticket field edit dialog to the project page and wires the existing edit buttons into that dialog instead of `prompt()`.

The new editor supports:
- single-line input for title
- multiline textarea editing for description
- constrained select-based editing for priority
- inline validation and error display inside the dashboard UI
- cancel, backdrop-close, and escape behavior that stays inside the dashboard interaction model

The existing `/api/ticket/<slug>/<num>/edit` endpoint remains the save path, so the change is scoped to the dashboard UX rather than the server contract.

## Validation
I verified this change with:
- `python3 -m pytest -q test_agentplan.py -k 'dashboard_project_detail_includes_ticket_field_edit_dialog or dashboard_ticket_edit_endpoint_updates_supported_fields or dashboard_project_detail_script_uses_real_ticket_field_editor or dashboard_project_detail_includes_editable_directory_field'`
- `python3 -m compileall agentplan`

The tests cover the presence of the new dialog structure, the continued behavior of the edit endpoint for title/description/priority updates, and a regression guard that ensures `prompt()` is no longer present in `project.js`.
