### PR TITLE
[codex] dashboard home polish

### DIFF
--- a/agentplan/dashboard/routes.py
+++ b/agentplan/dashboard/routes.py
@@ -47,6 +47,20 @@ _CONTEXT_PIDS = {}
 _CONTEXT_LOCK = threading.Lock()
 LOGGER = logging.getLogger(__name__)
 
+HOME_STATUS_LABELS = {
+    "active": "Active",
+    "completed": "Completed",
+    "abandoned": "Closed",
+    "archived": "Archived",
+}
+
+HOME_SECTION_ORDER = [
+    ("active", "Active Projects"),
+    ("completed", "Completed Projects"),
+    ("abandoned", "Closed Projects"),
+    ("archived", "Archived Projects"),
+]
+
 
 def _get_context_pid(slug):
     value = _CONTEXT_PIDS.get(slug)
@@ -268,6 +282,42 @@ def _project_context_payload(project):
     return {"exists": True, "html": _markdown_to_html(raw), "raw": raw}
 
 
+def _titleize_status(status):
+    words = [part for part in str(status or "").replace("_", "-").split("-") if part]
+    if not words:
+        return "Unknown"
+    return " ".join(word.capitalize() for word in words)
+
+
+def _home_status_label(status):
+    normalized = (status or "").strip().lower()
+    return HOME_STATUS_LABELS.get(normalized, _titleize_status(normalized))
+
+
+def _group_projects_for_home(projects):
+    grouped = defaultdict(list)
+    for project in projects:
+        grouped[(project.get("status") or "unknown").strip().lower()].append(project)
+
+    sections = []
+    for key, title in HOME_SECTION_ORDER:
+        items = grouped.pop(key, [])
+        sections.append({"key": key, "title": title, "projects": items})
+
+    for key in sorted(grouped):
+        items = grouped[key]
+        if items:
+            sections.append(
+                {
+                    "key": key,
+                    "title": f"{_home_status_label(key)} Projects",
+                    "projects": items,
+                }
+            )
+
+    return sections
+
+
 def _fetch_projects_with_stats(conn):
     projects = conn.execute(
         "SELECT id, slug, title, status, updated_at, dir FROM projects ORDER BY updated_at DESC, id DESC LIMIT 100"
@@ -313,6 +363,7 @@ def _fetch_projects_with_stats(conn):
                 "in_flight_count": in_flight,
                 "progress_pct": progress,
                 "missing_directory": bool(p["dir"] and not os.path.isdir(p["dir"])),
+                "status_label": _home_status_label(p["status"]),
             }
         )
     return out
@@ -403,7 +454,7 @@ def _project_stats_payload():
         conn.close()
 
     summary = {
-        "active_projects": sum(1 for p in projects if p["status"] != "completed"),
+        "active_projects": sum(1 for p in projects if p["status"] == "active"),
         "tickets_in_flight": sum(p["in_flight_count"] for p in projects),
         "completed_today": int(completed_today or 0),
         "active_agents": int(active_agents or 0),
@@ -749,15 +800,16 @@ def create_app():
     def index():
         payload = _project_stats_payload()
         projects = payload["projects"]
-        active_projects = [p for p in projects if p["status"] != "completed" and p["status"] != "archived"]
-        completed_projects = [p for p in projects if p["status"] == "completed"]
         return render_template(
             "home.html",
             projects=projects,
-            active_projects=active_projects,
-            completed_projects=completed_projects,
+            home_sections=_group_projects_for_home(projects),
             summary=payload["summary"],
         )
+
+    @app.route("/favicon.ico")
+    def favicon():
+        return redirect(url_for("static", filename="favicon.svg"), code=308)
 
     @app.route("/api/stats")
     def api_stats():

--- a/agentplan/dashboard/static/favicon.svg
+++ b/agentplan/dashboard/static/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="agentplan-favicon-bg" x1="0%" x2="100%" y1="0%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="100%" stop-color="#1d4ed8"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="url(#agentplan-favicon-bg)"/>
+  <path d="M18 42L27 22H33L24 42H18ZM31 42L40 22H46L37 42H31Z" fill="#f8fafc"/>
+  <circle cx="47" cy="18" r="5" fill="#34d399"/>
+</svg>

--- a/agentplan/dashboard/static/style.css
+++ b/agentplan/dashboard/static/style.css
@@ -168,19 +168,70 @@ h1 { font-family: var(--font-heading); }
   font-weight: var(--fw-h1);
   line-height: 1;
 }
-.project-section-title { margin: 0 0 10px; font-family: var(--font-body); font-size: var(--fs-h2); font-weight: var(--fw-h2); letter-spacing: 0.02em; }
+.project-sections { display: grid; gap: 18px; }
+.project-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
+.project-section-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+.project-section-toggle-icon {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-right: 2px solid var(--color-muted);
+  border-bottom: 2px solid var(--color-muted);
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+.project-section-toggle[aria-expanded="false"] .project-section-toggle-icon {
+  transform: rotate(-45deg);
+}
+.project-section-title { margin: 0; font-family: var(--font-body); font-size: var(--fs-h2); font-weight: var(--fw-h2); letter-spacing: 0.02em; }
+.project-section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  padding: 0.15rem 0.55rem;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  color: var(--color-muted);
+  font-family: var(--font-mono);
+  font-size: var(--fs-mono);
+}
+.project-sections[hidden],
+.projects-grid[hidden],
+.empty[hidden] {
+  display: none !important;
+}
+.project-section-toggle:focus-visible {
+  outline: 2px solid rgba(59,130,246,0.55);
+  outline-offset: 4px;
+  border-radius: 8px;
+}
 .projects-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
 .project-section { margin-bottom: 18px; }
-.toggle-row { margin-bottom: 12px; display: flex; justify-content: flex-end; }
-.toggle-label { display: inline-flex; align-items: center; gap: 8px; color: var(--color-muted); font-family: var(--font-body); font-size: var(--fs-small); font-weight: var(--fw-small); }
+.project-section-empty {
+  grid-column: 1 / -1;
+  border: 1px dashed var(--color-border);
+  border-radius: 14px;
+  padding: 16px;
+  color: var(--color-muted);
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+}
 .home-toolbar { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; margin: 0 0 18px; }
 .home-toolbar-copy { display: grid; gap: 6px; }
 .home-title { margin: 0; font-size: var(--fs-h1); font-weight: var(--fw-h1); }
 .home-subtitle { margin: 0; max-width: 44rem; color: var(--color-muted); font-family: var(--font-body); font-size: var(--fs-body); line-height: 1.5; }
 .home-create-btn { white-space: nowrap; }
-.projects-grid.completed .project-card { padding: 12px; opacity: 0.9; }
 .project-card-shell { position: relative; overflow: visible; z-index: 0; }
-.project-card-shell.menu-open { z-index: 30; }
+.project-card-shell.menu-open { z-index: 80; }
 .project-link { display: block; color: inherit; text-decoration: none; }
 .project-card {
   position: relative;
@@ -188,12 +239,13 @@ h1 { font-family: var(--font-heading); }
   border: 1px solid var(--color-border);
   border-radius: 14px;
   box-shadow: 0 12px 36px var(--color-shadow);
-  padding: 16px;
-  padding-right: 56px;
+  min-height: 100%;
+  padding: 18px;
+  padding-right: 68px;
   transition: transform 0.4s ease, border-color 0.4s ease, box-shadow 0.4s ease, opacity 0.3s ease;
 }
 .project-link:hover .project-card { transform: translateY(-1px); border-color: rgba(255,255,255,0.16); }
-.project-card-menu { position: absolute; top: 10px; right: 10px; z-index: 40; }
+.project-card-menu { position: absolute; top: 14px; right: 14px; z-index: 90; }
 .kebab-btn {
   width: 34px;
   height: 34px;
@@ -270,9 +322,43 @@ h1 { font-family: var(--font-heading); }
   outline: 2px solid rgba(59,130,246,0.55);
   outline-offset: 2px;
 }
+.project-heading { min-width: 0; }
 .project-top { display: flex; justify-content: space-between; align-items: flex-start; gap: 10px; }
 .project-title { margin: 0; font-family: var(--font-body); font-weight: var(--fw-card-title); font-size: var(--fs-card-title); line-height: 1.2; }
 .project-code { margin-top: 4px; font-family: var(--font-mono); font-size: var(--fs-mono); color: var(--color-muted); }
+.project-status-row { margin-top: 10px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.project-status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.22rem 0.62rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--fs-small);
+  font-weight: var(--fw-button);
+}
+.project-status-badge.status-active {
+  border-color: rgba(59, 130, 246, 0.45);
+  background: rgba(37, 99, 235, 0.18);
+  color: #bfdbfe;
+}
+.project-status-badge.status-completed {
+  border-color: rgba(74, 222, 128, 0.35);
+  background: rgba(34, 197, 94, 0.16);
+  color: #bbf7d0;
+}
+.project-status-badge.status-abandoned {
+  border-color: rgba(251, 191, 36, 0.35);
+  background: rgba(217, 119, 6, 0.18);
+  color: #fde68a;
+}
+.project-status-badge.status-archived {
+  border-color: rgba(148, 163, 184, 0.35);
+  background: rgba(71, 85, 105, 0.24);
+  color: #cbd5e1;
+}
 .progress-ring {
   --ring-size: 56px;
   --ring-stroke: 3.6;
@@ -294,16 +380,6 @@ h1 { font-family: var(--font-heading); }
 .project-warning { margin-top: 6px; display: inline-flex; align-items: center; gap: 6px; padding: 2px 8px; border-radius: 999px; border: 1px solid rgba(245, 158, 11, 0.45); background: rgba(120, 53, 15, 0.35); color: #fde68a; font-size: var(--fs-small); font-family: var(--font-body); }
 .project-progress-text,
 .project-last-activity { font-family: var(--font-body); font-weight: var(--fw-body); font-size: var(--fs-small); color: var(--color-muted); }
-.dot-breakdown { display: flex; flex-wrap: wrap; gap: 8px 10px; }
-.dot-item { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-body); font-weight: var(--fw-body); font-size: var(--fs-small); color: var(--color-muted); }
-.dot { width: 8px; height: 8px; border-radius: 50%; }
-.dot.pending { background: var(--status-pending); }
-.dot.in-progress { background: var(--status-in-progress); }
-.dot.blocked { background: var(--status-blocked); }
-.dot.needs-review { background: var(--status-needs-review); }
-.dot.failed { background: var(--status-failed); }
-.dot.done { background: var(--status-done); }
-.dot.skipped { background: var(--status-skipped); }
 .empty { border: 1px dashed var(--color-border); border-radius: 14px; padding: 24px; color: var(--color-muted); }
 
 /* Activity */

--- a/agentplan/dashboard/templates/base.html
+++ b/agentplan/dashboard/templates/base.html
@@ -7,6 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700;900&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="icon" href="{{ url_for('static', filename='favicon.svg') }}" type="image/svg+xml">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     {% block extra_head %}{% endblock %}
   </head>

--- a/agentplan/dashboard/templates/home.html
+++ b/agentplan/dashboard/templates/home.html
@@ -4,6 +4,61 @@
 {% block title %}agentplan dashboard{% endblock %}
 {% block body_class %}dashboard-home{% endblock %}
 
+{% macro project_card(project) -%}
+<article class="project-card-shell" data-project-shell data-project-slug="{{ project.slug }}">
+  <div class="project-card-menu">
+    <button
+      type="button"
+      class="kebab-btn"
+      aria-label="Project actions for {{ project.title }}"
+      aria-expanded="false"
+      aria-haspopup="menu"
+      data-project-menu-button
+      data-project-id="{{ project.id }}"
+      data-project-slug="{{ project.slug }}"
+      data-project-title="{{ project.title }}"
+      data-project-status="{{ project.status }}"
+    >⋯</button>
+    <div class="kebab-menu" data-project-menu hidden>
+      {% if project.status not in ["completed", "archived", "abandoned"] %}
+      <button type="button" class="kebab-menu-item" data-project-action="close">Close</button>
+      {% endif %}
+      {% if project.status != "archived" %}
+      <button type="button" class="kebab-menu-item" data-project-action="archive">Archive</button>
+      {% endif %}
+      <button type="button" class="kebab-menu-item danger" data-project-action="delete">Delete</button>
+    </div>
+  </div>
+  <a class="project-link" href="{{ url_for('project_detail', slug=project.slug) }}" data-project-id="{{ project.id }}" data-project-status="{{ project.status }}" data-project-slug="{{ project.slug }}" aria-label="Open {{ project.title }}">
+    <article class="project-card">
+      <div class="project-top">
+        <div class="project-heading">
+          <h2 class="project-title">{{ project.title }}</h2>
+          <div class="project-code">{{ project.slug }}</div>
+          <div class="project-status-row">
+            <span class="project-status-badge status-{{ project.status }}">{{ project.status_label }}</span>
+          </div>
+        </div>
+        <div class="progress-ring" style="--ring-progress: {{ project.progress_pct }};" aria-hidden="true">
+          <svg viewBox="0 0 36 36">
+            <circle class="progress-ring-track" cx="18" cy="18" r="16"></circle>
+            <circle class="progress-ring-value" cx="18" cy="18" r="16"></circle>
+          </svg>
+          <span class="progress-ring-label project-progress-percent">{{ project.progress_pct }}%</span>
+        </div>
+      </div>
+      <div class="project-meta">
+        <div class="project-progress-text"><strong class="project-progress-done">{{ project.done_count }}</strong>/<span class="project-progress-total">{{ project.ticket_count }}</span> done</div>
+        <div class="project-last-activity">Last activity: <span class="project-updated-at" data-timestamp="{{ project.updated_at or '' }}">{{ project.updated_at or "n/a" }}</span></div>
+        {% if project.missing_directory %}
+        <div class="project-warning" title="Linked directory is missing on disk">⚠ Missing directory</div>
+        {% endif %}
+      </div>
+    </article>
+  </a>
+</article>
+{%- endmacro %}
+
 {% block content %}
 <section class="home-toolbar">
   <div class="home-toolbar-copy">
@@ -44,137 +99,56 @@
   </form>
 </dialog>
 
-{% if projects %}
-<div class="toggle-row">
-  <label class="toggle-label"><input id="show-completed" type="checkbox"> Show completed</label>
+<div id="project-sections" class="project-sections"{% if not projects %} hidden{% endif %}>
+  {% if projects %}
+  {% for section in home_sections %}
+  {% set section_open = home_sections|length == 1 or section.key == "active" %}
+  <section class="project-section" data-project-section data-status-section="{{ section.key }}">
+    <div class="project-section-heading">
+      <button
+        type="button"
+        class="project-section-toggle"
+        data-section-toggle
+        data-section-key="{{ section.key }}"
+        aria-expanded="{{ 'true' if section_open else 'false' }}"
+      >
+        <span class="project-section-toggle-icon" aria-hidden="true"></span>
+        <span class="project-section-title">{{ section.title }}</span>
+      </button>
+      <span class="project-section-count">{{ section.projects|length }}</span>
+    </div>
+    <section class="projects-grid"{% if not section_open %} hidden{% endif %}>
+      {% if section.projects %}
+      {% for project in section.projects %}
+      {{ project_card(project) }}
+      {% endfor %}
+      {% else %}
+      <div class="project-section-empty">No {{ section.title|lower }} yet.</div>
+      {% endif %}
+    </section>
+  </section>
+  {% endfor %}
+  {% endif %}
 </div>
-
-<section class="project-section" id="active-section">
-  <h2 class="project-section-title">Active Projects</h2>
-  <section class="projects-grid" id="active-projects-grid">
-    {% for project in active_projects %}
-    <article class="project-card-shell" data-project-shell data-project-slug="{{ project.slug }}">
-      <div class="project-card-menu">
-        <button
-          type="button"
-          class="kebab-btn"
-          aria-label="Project actions for {{ project.title }}"
-          aria-expanded="false"
-          aria-haspopup="menu"
-          data-project-menu-button
-          data-project-id="{{ project.id }}"
-          data-project-slug="{{ project.slug }}"
-          data-project-title="{{ project.title }}"
-          data-project-status="{{ project.status }}"
-        >⋯</button>
-        <div class="kebab-menu" data-project-menu hidden>
-          {% if project.status not in ["completed", "archived", "abandoned"] %}
-          <button type="button" class="kebab-menu-item" data-project-action="close">Close</button>
-          {% endif %}
-          {% if project.status != "archived" %}
-          <button type="button" class="kebab-menu-item" data-project-action="archive">Archive</button>
-          {% endif %}
-          <button type="button" class="kebab-menu-item danger" data-project-action="delete">Delete</button>
-        </div>
-      </div>
-      <a class="project-link" href="{{ url_for('project_detail', slug=project.slug) }}" data-project-id="{{ project.id }}" data-project-status="{{ project.status }}" data-project-slug="{{ project.slug }}" aria-label="Open {{ project.title }}">
-        <article class="project-card">
-        <div class="project-top">
-          <div>
-            <h2 class="project-title">{{ project.title }}</h2>
-            <div class="project-code">{{ project.slug }}</div>
-          </div>
-          <div class="progress-ring" style="--ring-progress: {{ project.progress_pct }};" aria-hidden="true">
-            <svg viewBox="0 0 36 36">
-              <circle class="progress-ring-track" cx="18" cy="18" r="16"></circle>
-              <circle class="progress-ring-value" cx="18" cy="18" r="16"></circle>
-            </svg>
-            <span class="progress-ring-label project-progress-percent">{{ project.progress_pct }}%</span>
-          </div>
-        </div>
-        <div class="project-meta">
-          <div class="project-progress-text"><strong class="project-progress-done">{{ project.done_count }}</strong>/<span class="project-progress-total">{{ project.ticket_count }}</span> done</div>
-          <div class="dot-breakdown project-breakdown">
-            {% for status in ["pending", "in-progress", "blocked", "needs-review", "failed", "done"] %}
-            <span class="dot-item"><span class="dot {{ status }}"></span><span class="dot-value" data-status="{{ status }}">{{ project.breakdown.get(status, 0) }}</span></span>
-            {% endfor %}
-          </div>
-          <div class="project-last-activity">Last activity: <span class="project-updated-at" data-timestamp="{{ project.updated_at or '' }}">{{ project.updated_at or "n/a" }}</span></div>
-          {% if project.missing_directory %}
-          <div class="project-warning" title="Linked directory is missing on disk">⚠ Missing directory</div>
-          {% endif %}
-        </div>
-        </article>
-      </a>
-    </article>
-    {% endfor %}
-  </section>
-</section>
-
-<section class="project-section" id="completed-section">
-  <h2 class="project-section-title">Completed</h2>
-  <section class="projects-grid completed" id="completed-projects-grid">
-    {% for project in completed_projects %}
-    <article class="project-card-shell" data-project-shell data-project-slug="{{ project.slug }}">
-      <div class="project-card-menu">
-        <button
-          type="button"
-          class="kebab-btn"
-          aria-label="Project actions for {{ project.title }}"
-          aria-expanded="false"
-          aria-haspopup="menu"
-          data-project-menu-button
-          data-project-id="{{ project.id }}"
-          data-project-slug="{{ project.slug }}"
-          data-project-title="{{ project.title }}"
-          data-project-status="{{ project.status }}"
-        >⋯</button>
-        <div class="kebab-menu" data-project-menu hidden>
-          {% if project.status not in ["completed", "archived", "abandoned"] %}
-          <button type="button" class="kebab-menu-item" data-project-action="close">Close</button>
-          {% endif %}
-          {% if project.status != "archived" %}
-          <button type="button" class="kebab-menu-item" data-project-action="archive">Archive</button>
-          {% endif %}
-          <button type="button" class="kebab-menu-item danger" data-project-action="delete">Delete</button>
-        </div>
-      </div>
-      <a class="project-link" href="{{ url_for('project_detail', slug=project.slug) }}" data-project-id="{{ project.id }}" data-project-status="{{ project.status }}" data-project-slug="{{ project.slug }}" aria-label="Open {{ project.title }}">
-        <article class="project-card">
-        <div class="project-top">
-          <div>
-            <h2 class="project-title">{{ project.title }}</h2>
-            <div class="project-code">{{ project.slug }}</div>
-          </div>
-          <div class="progress-ring" style="--ring-progress: {{ project.progress_pct }};" aria-hidden="true">
-            <svg viewBox="0 0 36 36">
-              <circle class="progress-ring-track" cx="18" cy="18" r="16"></circle>
-              <circle class="progress-ring-value" cx="18" cy="18" r="16"></circle>
-            </svg>
-            <span class="progress-ring-label project-progress-percent">{{ project.progress_pct }}%</span>
-          </div>
-        </div>
-        <div class="project-meta">
-          <div class="project-progress-text"><strong class="project-progress-done">{{ project.done_count }}</strong>/<span class="project-progress-total">{{ project.ticket_count }}</span> done</div>
-          <div class="project-last-activity">Last activity: <span class="project-updated-at" data-timestamp="{{ project.updated_at or '' }}">{{ project.updated_at or "n/a" }}</span></div>
-          {% if project.missing_directory %}
-          <div class="project-warning" title="Linked directory is missing on disk">⚠ Missing directory</div>
-          {% endif %}
-        </div>
-        </article>
-      </a>
-    </article>
-    {% endfor %}
-  </section>
-</section>
-{% else %}
-<div class="empty">No projects found.</div>
-{% endif %}
+<div class="empty" id="projects-empty-state"{% if projects %} hidden{% endif %}>No projects found.</div>
 {% endblock %}
 
 {% block scripts %}
 <script>
-  const statusOrder = ["pending", "in-progress", "blocked", "needs-review", "failed", "done"];
+  const homeSectionOrder = [
+    { key: "active", title: "Active Projects" },
+    { key: "completed", title: "Completed Projects" },
+    { key: "abandoned", title: "Closed Projects" },
+    { key: "archived", title: "Archived Projects" },
+  ];
+  const projectStatusLabels = {
+    active: "Active",
+    completed: "Completed",
+    abandoned: "Closed",
+    archived: "Archived",
+  };
+  const sectionStateStorageKey = "agentplan.dashboard.home.sectionState";
+  let homeSectionState = loadSectionState();
 
   function renderSummary(summary) {
     document.getElementById("stat-active-projects").textContent = summary.active_projects ?? 0;
@@ -208,6 +182,58 @@
     });
   }
 
+  function formatStatusLabel(status) {
+    const normalized = String(status || "").trim().toLowerCase();
+    if (projectStatusLabels[normalized]) return projectStatusLabels[normalized];
+    if (!normalized) return "Unknown";
+    return normalized
+      .split(/[-_]/g)
+      .filter(Boolean)
+      .map((part) => part[0].toUpperCase() + part.slice(1))
+      .join(" ");
+  }
+
+  function loadSectionState() {
+    try {
+      const raw = window.localStorage?.getItem(sectionStateStorageKey);
+      const parsed = raw ? JSON.parse(raw) : {};
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch (_err) {
+      return {};
+    }
+  }
+
+  function persistSectionState() {
+    try {
+      window.localStorage?.setItem(sectionStateStorageKey, JSON.stringify(homeSectionState));
+    } catch (_err) {
+      // Ignore storage failures.
+    }
+  }
+
+  function defaultSectionOpen(sectionKey, totalSections) {
+    return totalSections === 1 || sectionKey === "active";
+  }
+
+  function isSectionOpen(sectionKey, totalSections) {
+    if (Object.prototype.hasOwnProperty.call(homeSectionState, sectionKey)) {
+      return Boolean(homeSectionState[sectionKey]);
+    }
+    return defaultSectionOpen(sectionKey, totalSections);
+  }
+
+  function setSectionExpanded(sectionKey, expanded) {
+    const section = document.querySelector(`[data-status-section="${CSS.escape(sectionKey)}"]`);
+    const toggle = section?.querySelector("[data-section-toggle]");
+    const grid = section?.querySelector(".projects-grid");
+    if (toggle) {
+      toggle.setAttribute("aria-expanded", expanded ? "true" : "false");
+    }
+    if (grid) {
+      grid.hidden = !expanded;
+    }
+  }
+
   function projectMenuMarkup(project) {
     const status = project.status || "";
     const title = esc(project.title || "");
@@ -220,11 +246,48 @@
     return `<div class="project-card-menu"><button type="button" class="kebab-btn" aria-label="Project actions for ${title}" aria-expanded="false" aria-haspopup="menu" data-project-menu-button data-project-id="${project.id}" data-project-slug="${esc(project.slug || "")}" data-project-title="${title}" data-project-status="${esc(status)}">⋯</button><div class="kebab-menu" data-project-menu hidden>${maybeClose}${maybeArchive}<button type="button" class="kebab-menu-item danger" data-project-action="delete">Delete</button></div></div>`;
   }
 
-  function projectCard(project, isCompleted) {
-    const breakdown = project.breakdown || {};
-    const breakdownHtml = isCompleted ? '' : `<div class="dot-breakdown project-breakdown">${statusOrder.map((status) => `<span class="dot-item"><span class="dot ${status}"></span><span class="dot-value" data-status="${status}">${breakdown[status] || 0}</span></span>`).join("")}</div>`;
+  function projectCard(project) {
     const warningHtml = project.missing_directory ? `<div class="project-warning" title="Linked directory is missing on disk">⚠ Missing directory</div>` : "";
-    return `<article class="project-card-shell" data-project-shell data-project-slug="${esc(project.slug || "")}">${projectMenuMarkup(project)}<a class="project-link" href="/project/${encodeURIComponent(project.slug)}" data-project-id="${project.id}" data-project-status="${esc(project.status || '')}" data-project-slug="${esc(project.slug || "")}" aria-label="Open ${esc(project.title)}"><article class="project-card"><div class="project-top"><div><h2 class="project-title">${esc(project.title)}</h2><div class="project-code">${esc(project.slug)}</div></div><div class="progress-ring" style="--ring-progress: ${project.progress_pct || 0};" aria-hidden="true"><svg viewBox="0 0 36 36"><circle class="progress-ring-track" cx="18" cy="18" r="16"></circle><circle class="progress-ring-value" cx="18" cy="18" r="16"></circle></svg><span class="progress-ring-label project-progress-percent">${project.progress_pct || 0}%</span></div></div><div class="project-meta"><div class="project-progress-text"><strong class="project-progress-done">${project.done_count || 0}</strong>/<span class="project-progress-total">${project.ticket_count || 0}</span> done</div>${breakdownHtml}<div class="project-last-activity">Last activity: <span class="project-updated-at" data-timestamp="${esc(project.updated_at || '')}">${formatRelative(project.updated_at)}</span></div>${warningHtml}</div></article></a></article>`;
+    const status = String(project.status || "").trim().toLowerCase();
+    const statusLabel = esc(project.status_label || formatStatusLabel(status));
+    return `<article class="project-card-shell" data-project-shell data-project-slug="${esc(project.slug || "")}">${projectMenuMarkup(project)}<a class="project-link" href="/project/${encodeURIComponent(project.slug)}" data-project-id="${project.id}" data-project-status="${esc(status)}" data-project-slug="${esc(project.slug || "")}" aria-label="Open ${esc(project.title)}"><article class="project-card"><div class="project-top"><div class="project-heading"><h2 class="project-title">${esc(project.title)}</h2><div class="project-code">${esc(project.slug)}</div><div class="project-status-row"><span class="project-status-badge status-${esc(status)}">${statusLabel}</span></div></div><div class="progress-ring" style="--ring-progress: ${project.progress_pct || 0};" aria-hidden="true"><svg viewBox="0 0 36 36"><circle class="progress-ring-track" cx="18" cy="18" r="16"></circle><circle class="progress-ring-value" cx="18" cy="18" r="16"></circle></svg><span class="progress-ring-label project-progress-percent">${project.progress_pct || 0}%</span></div></div><div class="project-meta"><div class="project-progress-text"><strong class="project-progress-done">${project.done_count || 0}</strong>/<span class="project-progress-total">${project.ticket_count || 0}</span> done</div><div class="project-last-activity">Last activity: <span class="project-updated-at" data-timestamp="${esc(project.updated_at || '')}">${formatRelative(project.updated_at)}</span></div>${warningHtml}</div></article></a></article>`;
+  }
+
+  function groupProjects(projects) {
+    const groups = new Map(homeSectionOrder.map((section) => [section.key, []]));
+    const extras = new Map();
+    (projects || []).forEach((project) => {
+      const key = String(project.status || "unknown").trim().toLowerCase();
+      if (groups.has(key)) {
+        groups.get(key).push(project);
+        return;
+      }
+      if (!extras.has(key)) extras.set(key, []);
+      extras.get(key).push(project);
+    });
+
+    const sections = homeSectionOrder
+      .map((section) => ({ ...section, projects: groups.get(section.key) || [] }));
+
+    Array.from(extras.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([key, items]) => {
+        sections.push({
+          key,
+          title: `${formatStatusLabel(key)} Projects`,
+          projects: items,
+        });
+      });
+
+    return sections;
+  }
+
+  function renderProjectSection(section) {
+    const expanded = isSectionOpen(section.key, groupProjects(window.__latestProjects || []).length || 1);
+    const content = section.projects.length
+      ? section.projects.map((project) => projectCard(project)).join("")
+      : `<div class="project-section-empty">No ${esc(section.title.toLowerCase())} yet.</div>`;
+    return `<section class="project-section" data-project-section data-status-section="${esc(section.key)}"><div class="project-section-heading"><button type="button" class="project-section-toggle" data-section-toggle data-section-key="${esc(section.key)}" aria-expanded="${expanded ? "true" : "false"}"><span class="project-section-toggle-icon" aria-hidden="true"></span><span class="project-section-title">${esc(section.title)}</span></button><span class="project-section-count">${section.projects.length}</span></div><section class="projects-grid"${expanded ? "" : " hidden"}>${content}</section></section>`;
   }
 
   function getOpenProjectMenuSlug() {
@@ -262,31 +325,28 @@
 
   function renderProjects(projects) {
     const openMenuSlug = getOpenProjectMenuSlug();
-    const showCompleted = document.getElementById("show-completed")?.checked;
-    const visible = projects || [];
-    const active = visible.filter((p) => p.status !== "completed");
-    const completed = visible.filter((p) => p.status === "completed");
-
-    const activeGrid = document.getElementById("active-projects-grid");
-    const completedGrid = document.getElementById("completed-projects-grid");
-    if (activeGrid) activeGrid.innerHTML = active.map((p) => projectCard(p, false)).join("");
-    const completedSection = document.getElementById("completed-section");
-    if (completedSection) completedSection.style.display = showCompleted ? "" : "none";
-    if (completedGrid) completedGrid.innerHTML = completed.map((p) => projectCard(p, true)).join("");
+    const projectSections = document.getElementById("project-sections");
+    const emptyState = document.getElementById("projects-empty-state");
+    const sections = groupProjects(projects || []);
+    if (projectSections) {
+      projectSections.innerHTML = sections.map((section) => renderProjectSection(section)).join("");
+      projectSections.hidden = sections.length === 0;
+    }
+    if (emptyState) emptyState.hidden = sections.length !== 0;
     applyRelativeTimes();
     restoreProjectMenu(openMenuSlug);
   }
 
   setClock("live-clock");
   setInterval(() => setClock("live-clock"), 1000);
-  applyRelativeTimes();
+  window.__latestProjects = {{ projects|tojson }};
+  renderProjects(window.__latestProjects);
 
   const createProjectDialog = document.getElementById("create-project-dialog");
   const createProjectForm = document.getElementById("create-project-form");
   const createProjectTitle = document.getElementById("create-project-title");
   const openCreateProjectButton = document.getElementById("open-create-project-dialog");
   const cancelCreateProjectButton = document.getElementById("cancel-create-project");
-  const projectGrids = [document.getElementById("active-projects-grid"), document.getElementById("completed-projects-grid")].filter(Boolean);
 
   async function postProjectAction(slug, action, body) {
     const response = await fetch(`/api/project/${encodeURIComponent(slug)}/${action}`, {
@@ -400,9 +460,6 @@
     }
   });
 
-  const completedToggle = document.getElementById("show-completed");
-  if (completedToggle) completedToggle.addEventListener("change", () => renderProjects(window.__latestProjects || []));
-
   document.addEventListener("click", (event) => {
     const menuButton = event.target.closest("[data-project-menu-button]");
     if (menuButton) {
@@ -431,6 +488,19 @@
 
     if (!event.target.closest(".project-card-menu")) {
       closeProjectMenus();
+    }
+
+    const sectionToggle = event.target.closest("[data-section-toggle]");
+    if (sectionToggle) {
+      event.preventDefault();
+      const sectionKey = sectionToggle.dataset.sectionKey || "";
+      if (!sectionKey) return;
+      const sections = groupProjects(window.__latestProjects || []);
+      const currentlyOpen = isSectionOpen(sectionKey, sections.length || 1);
+      const nextOpen = !currentlyOpen;
+      homeSectionState[sectionKey] = nextOpen;
+      persistSectionState();
+      setSectionExpanded(sectionKey, nextOpen);
     }
   });
 

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -1404,6 +1404,10 @@ def test_dashboard_home_includes_create_dialog_and_project_kebab_menu():
     assert 'data-project-action="delete"' in body
     assert "handleProjectAction" in body
     assert "restoreProjectMenu" in body
+    assert "project-status-badge" in body
+    assert 'data-section-toggle' in body
+    assert 'rel="icon"' in body
+    assert 'favicon.svg' in body
 
 
 def test_dashboard_home_project_menu_is_outside_project_link():
@@ -1423,6 +1427,78 @@ def test_dashboard_home_project_menu_is_outside_project_link():
     assert shell_html.index('class="project-card-menu"') < shell_html.index('class="project-link"')
 
 
+def test_dashboard_home_groups_projects_by_status_and_shows_status_badges():
+    from agentplan.dashboard import app
+
+    cli("create", "Web Home Active")
+    cli("create", "Web Home Completed")
+    cli("create", "Web Home Closed")
+    cli("create", "Web Home Archived")
+    cli("close", "web-home-completed")
+    cli("close", "web-home-closed", "--abandon")
+    cli("close", "web-home-archived")
+    cli("archive", "web-home-archived")
+
+    client = app.test_client()
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert "Active Projects" in body
+    assert "Completed Projects" in body
+    assert "Closed Projects" in body
+    assert "Archived Projects" in body
+    assert 'data-status-section="archived"' in body
+    assert "status-active" in body
+    assert "status-completed" in body
+    assert "status-abandoned" in body
+    assert "status-archived" in body
+    assert ">Active<" in body
+    assert ">Completed<" in body
+    assert ">Closed<" in body
+    assert ">Archived<" in body
+    assert "dot-breakdown" not in body
+    assert 'id="show-completed"' not in body
+
+
+def test_dashboard_home_sections_are_collapsible():
+    from agentplan.dashboard import app
+
+    cli("create", "Collapse Active")
+    cli("create", "Collapse Completed")
+    cli("close", "collapse-completed")
+
+    client = app.test_client()
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'data-section-toggle' in body
+    assert 'data-section-key="active"' in body
+    assert 'data-section-key="completed"' in body
+    assert 'aria-expanded="true"' in body
+    assert 'aria-expanded="false"' in body
+    assert 'sectionStateStorageKey' in body
+    assert 'localStorage?.setItem' in body
+    assert 'function setSectionExpanded(sectionKey, expanded)' in body
+    assert 'grid.hidden = !expanded;' in body
+
+
+def test_dashboard_home_shows_archived_section_even_when_empty():
+    from agentplan.dashboard import app
+
+    cli("create", "Only Active Home")
+
+    client = app.test_client()
+    resp = client.get("/")
+
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'data-status-section="archived"' in body
+    assert "Archived Projects" in body
+    assert "No archived projects yet." in body
+
+
 def test_dashboard_home_hides_close_action_for_completed_projects():
     from agentplan.dashboard import app
 
@@ -1438,6 +1514,36 @@ def test_dashboard_home_hides_close_action_for_completed_projects():
     assert 'data-project-action="archive"' in completed_fragment
     assert 'data-project-action="delete"' in completed_fragment
     assert 'data-project-action="close"' not in completed_fragment
+
+
+def test_dashboard_home_active_summary_counts_only_active_projects():
+    from agentplan.dashboard import app
+
+    cli("create", "Summary Active")
+    cli("create", "Summary Completed")
+    cli("create", "Summary Closed")
+    cli("create", "Summary Archived")
+    cli("close", "summary-completed")
+    cli("close", "summary-closed", "--abandon")
+    cli("close", "summary-archived")
+    cli("archive", "summary-archived")
+
+    client = app.test_client()
+    resp = client.get("/api/stats")
+
+    assert resp.status_code == 200
+    payload = resp.get_json()
+    assert payload["summary"]["active_projects"] == 1
+
+
+def test_dashboard_favicon_route_redirects_to_static_asset():
+    from agentplan.dashboard import app
+
+    client = app.test_client()
+    resp = client.get("/favicon.ico", follow_redirects=False)
+
+    assert resp.status_code == 308
+    assert resp.headers["Location"].endswith("/static/favicon.svg")
 
 
 def test_dashboard_project_detail_returns_ticket_titles():


### PR DESCRIPTION
## Summary
The dashboard home page still behaved like the older two-bucket design and was missing some basic polish. Completed-card kebab buttons could overlap card content, project cards did not show an explicit project status, the homepage still rendered noisy per-ticket-status dot breakdowns, and the page only meaningfully modeled active versus completed work. On top of that, section collapsing was added but needed to become part of the real home-page structure, and browsers were logging a favicon 404.

## User Impact
Users browsing the dashboard home page had to infer project state, scroll through long project lists, and deal with inconsistent card chrome across statuses. Archived projects were easy to miss, the active-project metric could mislead, and the missing favicon created unnecessary console noise during normal use.

## Root Cause
The homepage had drifted into duplicated and outdated status logic. Server-rendered and client-rendered home views were both anchored to an older active/completed split, summary metrics treated every non-completed project as active, and the card UI carried extra detail that no longer matched the intended information density. The favicon path was also never defined.

## Fix
This change reworks the dashboard home page around explicit project-status sections. The home view now groups projects by real project status, shows visible status badges on cards, always includes the core sections including Archived Projects, removes the old dot breakdown, and makes the status sections collapsible with persisted state. The completed-card overlap issue is resolved by standardizing card spacing and menu stacking. The dashboard now also serves a real favicon and redirects `/favicon.ico` to the static asset.

## Validation
I validated the change with:

- `python3 -m pytest -q test_agentplan.py -k 'dashboard_home or dashboard_favicon_route_redirects_to_static_asset'`
- `python3 -m compileall agentplan`
