### PR TITLE
[codex] simplify dashboard filters

### DIFF
--- a/agentplan/dashboard/routes.py
+++ b/agentplan/dashboard/routes.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Read-only web dashboard for agentplan projects and tickets."""
 
-import html
 import json
 import logging
 import os
@@ -231,57 +230,6 @@ def _context_path_for_project(project):
     return os.path.join(project_dir, ".agentplan.md")
 
 
-def _markdown_to_html(md_text):
-    if not md_text:
-        return ""
-    lines = md_text.splitlines()
-    rendered = []
-    in_list = False
-    for raw in lines:
-        line = raw.rstrip()
-        esc = html.escape(line)
-        if line.startswith("# "):
-            if in_list:
-                rendered.append("</ul>")
-                in_list = False
-            rendered.append(f"<h3>{html.escape(line[2:])}</h3>")
-        elif line.startswith("## "):
-            if in_list:
-                rendered.append("</ul>")
-                in_list = False
-            rendered.append(f"<h4>{html.escape(line[3:])}</h4>")
-        elif line.startswith("- "):
-            if not in_list:
-                rendered.append("<ul>")
-                in_list = True
-            rendered.append(f"<li>{html.escape(line[2:])}</li>")
-        elif line.strip() == "":
-            if in_list:
-                rendered.append("</ul>")
-                in_list = False
-            rendered.append("<br>")
-        else:
-            if in_list:
-                rendered.append("</ul>")
-                in_list = False
-            rendered.append(f"<p>{esc}</p>")
-    if in_list:
-        rendered.append("</ul>")
-    return "\n".join(rendered)
-
-
-def _project_context_payload(project):
-    context_path = _context_path_for_project(project)
-    if not context_path or not os.path.exists(context_path):
-        return {"exists": False, "html": "", "raw": ""}
-    try:
-        with open(context_path, "r", encoding="utf-8") as f:
-            raw = f.read()
-    except Exception:
-        return {"exists": False, "html": "", "raw": ""}
-    return {"exists": True, "html": _markdown_to_html(raw), "raw": raw}
-
-
 def _titleize_status(status):
     words = [part for part in str(status or "").replace("_", "-").split("-") if part]
     if not words:
@@ -369,11 +317,7 @@ def _fetch_projects_with_stats(conn):
     return out
 
 
-def _ticket_matches(ticket, status_filter, priority_filter, tag_filter):
-    if status_filter:
-        normalized_status = "pending" if status_filter == "todo" else status_filter
-        if ticket["status"] != normalized_status:
-            return False
+def _ticket_matches(ticket, priority_filter, tag_filter):
     if priority_filter:
         ticket_priority = str(ticket.get("priority") or "").strip().lower()
         if ticket_priority != priority_filter:
@@ -704,8 +648,7 @@ def _ticket_detail_payload(conn, project_id, ticket_num):
 
 
 
-def _project_board_payload(slug, status_filter="", priority_filter="", tag_filter=""):
-    status_filter = (status_filter or "").strip().lower()
+def _project_board_payload(slug, priority_filter="", tag_filter=""):
     priority_filter = (priority_filter or "").strip().lower()
     tag_filter = (tag_filter or "").strip().lower()
 
@@ -776,7 +719,7 @@ def _project_board_payload(slug, status_filter="", priority_filter="", tag_filte
             group_key = "done"
         if group_key not in grouped:
             continue
-        if _ticket_matches(ticket, status_filter, priority_filter, tag_filter):
+        if _ticket_matches(ticket, priority_filter, tag_filter):
             grouped[group_key].append(ticket)
 
     return {
@@ -823,7 +766,6 @@ def create_app():
         except (ValueError, TypeError):
             interval = 2
         project_slug = (request.args.get("project") or "").strip()
-        status_filter = request.args.get("status", "")
         priority_filter = request.args.get("priority", "")
         tag_filter = request.args.get("tag", "")
 
@@ -834,7 +776,7 @@ def create_app():
                 yield f"event: project_stats\ndata: {json.dumps(stats_payload)}\n\n"
                 yield f"event: activity_feed\ndata: {json.dumps(activity_payload)}\n\n"
                 if project_slug:
-                    board_payload = _project_board_payload(project_slug, status_filter, priority_filter, tag_filter)
+                    board_payload = _project_board_payload(project_slug, priority_filter, tag_filter)
                     if board_payload is not None:
                         yield f"event: project_board\ndata: {json.dumps(board_payload)}\n\n"
                 time.sleep(interval)
@@ -911,7 +853,6 @@ def create_app():
 
     @app.route("/project/<slug>")
     def project_detail(slug):
-        status_filter = request.args.get("status", "").strip().lower()
         priority_filter = request.args.get("priority", "").strip().lower()
         tag_filter = request.args.get("tag", "").strip().lower()
 
@@ -958,8 +899,6 @@ def create_app():
                     r["ticket_id"]: {"done": int(r["done"] or 0), "total": int(r["total"] or 0)} for r in progress_rows
                 }
 
-            context_payload = _project_context_payload(project)
-
             chain = get_chain_state(conn, project["id"]) or {}
             chain_current_ticket_num = None
             if chain.get("current_ticket_id"):
@@ -997,7 +936,7 @@ def create_app():
                 group_key = "done"
             if group_key not in grouped:
                 continue
-            if _ticket_matches(ticket, status_filter, priority_filter, tag_filter):
+            if _ticket_matches(ticket, priority_filter, tag_filter):
                 grouped[group_key].append(ticket)
 
         chain_status = (chain.get("status") or "stopped").lower()
@@ -1017,13 +956,12 @@ def create_app():
             status_labels=KANBAN_STATUS_LABELS,
             done_count=done_count,
             total_count=len(rows),
-            filters={"status": status_filter, "priority": priority_filter, "tag": tag_filter},
+            filters={"priority": priority_filter, "tag": tag_filter},
             available_tags=available_tags,
             chain=chain,
             chain_current_ticket_num=chain_current_ticket_num,
             chain_pause_reason=chain_pause_reason,
             chain_text=chain_text,
-            context_payload=context_payload,
             directory_warning=bool(project["dir"] and not os.path.isdir(project["dir"])),
         )
 

--- a/agentplan/dashboard/static/project.js
+++ b/agentplan/dashboard/static/project.js
@@ -627,10 +627,8 @@
   const dirSaveBtn = document.getElementById("project-dir-save-btn");
   const dirCancelBtn = document.getElementById("project-dir-cancel-btn");
   const dirWarning = document.getElementById("project-dir-warning");
-  const generateContextBtn = document.getElementById("generate-context-btn");
   const projectHeaderMenuButton = document.getElementById("project-header-menu-button");
   const projectHeaderMenu = document.getElementById("project-header-menu");
-  let contextPollingTimer = null;
 
   function closeProjectMenu() {
     if (projectHeaderMenuButton) projectHeaderMenuButton.setAttribute("aria-expanded", "false");
@@ -864,65 +862,6 @@
     });
   }
 
-  function setContextButtonState(isLoading) {
-    if (!generateContextBtn) return;
-    const label = generateContextBtn.querySelector(".btn-label");
-    generateContextBtn.disabled = Boolean(isLoading);
-    generateContextBtn.classList.toggle("is-loading", Boolean(isLoading));
-    if (label) label.textContent = isLoading ? "Generating..." : "Generate Repo Context";
-  }
-
-  function stopContextPolling() {
-    if (contextPollingTimer) {
-      clearInterval(contextPollingTimer);
-      contextPollingTimer = null;
-    }
-  }
-
-  async function pollContextStatus() {
-    try {
-      const response = await fetch(`/api/project/${encodeURIComponent(projectSlug)}/context-status`);
-      const payload = await response.json().catch(() => null);
-      if (!response.ok) throw new Error((payload && payload.error) || `HTTP ${response.status}`);
-      if (payload && payload.running) return;
-      stopContextPolling();
-      setContextButtonState(false);
-      window.location.reload();
-    } catch (error) {
-      stopContextPolling();
-      setContextButtonState(false);
-      showToast(error.message || "Failed to check context generation status.");
-    }
-  }
-
-  async function generateContext() {
-    setContextButtonState(true);
-    try {
-      const response = await fetch(`/api/project/${encodeURIComponent(projectSlug)}/generate-context`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      const payload = await response.json().catch(() => null);
-      if (!response.ok) throw new Error((payload && payload.error) || `HTTP ${response.status}`);
-      stopContextPolling();
-      contextPollingTimer = setInterval(pollContextStatus, 3000);
-      await pollContextStatus();
-    } catch (error) {
-      stopContextPolling();
-      setContextButtonState(false);
-      showToast(error.message || "Failed to start context generation.");
-    }
-  }
-
-  if (generateContextBtn) {
-    generateContextBtn.addEventListener("click", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      generateContext();
-    });
-  }
-
   if (projectHeaderMenuButton && projectHeaderMenu) {
     projectHeaderMenuButton.addEventListener("click", (event) => {
       event.preventDefault();
@@ -996,7 +935,6 @@
   });
 
   const params = new URLSearchParams({ project: projectSlug });
-  if (cfg.filters && cfg.filters.status) params.set("status", cfg.filters.status);
   if (cfg.filters && cfg.filters.priority) params.set("priority", cfg.filters.priority);
   if (cfg.filters && cfg.filters.tag) params.set("tag", cfg.filters.tag);
 

--- a/agentplan/dashboard/static/style.css
+++ b/agentplan/dashboard/static/style.css
@@ -101,6 +101,7 @@ code, pre, .mono { font-family: var(--font-mono); font-size: var(--text-sm); }
 .btn { border: 1px solid var(--color-border); border-radius: 8px; padding: 7px 10px; text-decoration: none; font-weight: var(--weight-medium); font-size: var(--text-xs); color: var(--color-muted); background: transparent; cursor: pointer; }
 .btn:hover { color: var(--color-text); background: rgba(255,255,255,0.05); }
 .btn-sm { padding: 3px 8px; font-size: var(--text-sm); border-radius: 6px; }
+.btn-secondary { color: var(--color-muted); background: transparent; border-color: var(--color-border); }
 .btn-primary { background: rgba(59,130,246,0.18); color: #dbeafe; border-color: rgba(59,130,246,0.35); }
 .btn-danger { border-color: rgba(239, 68, 68, 0.4); color: #fca5a5; }
 .sse-status { display: inline-flex; align-items: center; gap: 6px; }
@@ -391,9 +392,6 @@ code, pre, .mono { font-family: var(--font-mono); font-size: var(--text-sm); }
 .dashboard-activity .status-dot.connected { box-shadow: 0 0 0 0 rgba(34,197,94,0.55); animation: pulse-live 1.6s infinite; }
 .dashboard-activity .status-dot.disconnected { box-shadow: 0 0 0 4px rgba(239,68,68,0.15); animation: none; }
 .dashboard-activity .activity-shell { background: var(--color-panel); border: 1px solid var(--color-border); border-radius: 14px; box-shadow: 0 12px 36px var(--color-shadow); padding: 14px; }
-.dashboard-activity .filters-row { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 8px; }
-.dashboard-activity .filter-pill { border: 1px solid var(--color-border); background: transparent; color: var(--color-muted); border-radius: 999px; padding: 5px 11px; font-weight: var(--weight-medium); font-size: var(--text-xs); cursor: pointer; }
-.dashboard-activity .filter-pill.active { background: var(--color-panel-soft); color: var(--color-text); }
 .dashboard-activity .presence-line { margin: 0 0 12px; color: var(--color-muted); font-size: var(--text-xs); }
 .dashboard-activity .feed { max-height: 72vh; overflow: auto; display: grid; gap: 8px; padding-right: 2px; }
 .dashboard-activity .feed-day { margin-top: 10px; padding-bottom: 4px; border-bottom: 1px solid var(--color-border); color: var(--color-muted); font-weight: var(--weight-semibold); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.06em; }
@@ -468,17 +466,7 @@ code, pre, .mono { font-family: var(--font-mono); font-size: var(--text-sm); }
 .dashboard-project .btn-back.active { color: var(--color-text); text-decoration: underline; }
 .dashboard-project .project-meta { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 0 0 16px; color: var(--color-muted); font-size: var(--text-xs); }
 .dashboard-project .project-meta span { color: var(--color-muted); }
-.dashboard-project .context-panel { margin: 0 0 16px; border: 1px solid var(--color-border); border-radius: 10px; background: rgba(255,255,255,0.02); }
-.dashboard-project .context-panel summary { padding: 12px; cursor: pointer; font-weight: var(--weight-medium); list-style: none; display: flex; align-items: center; gap: 8px; }
-.dashboard-project .context-panel summary::before { content: "▸"; transition: transform 0.2s; }
-.dashboard-project .context-panel[open] summary::before { transform: rotate(90deg); }
-.dashboard-project .context-panel summary::-webkit-details-marker { display: none; }
-.dashboard-project #generate-context-btn { margin-left: auto; display: inline-flex; align-items: center; gap: 6px; }
-.dashboard-project #generate-context-btn .btn-spinner { width: 11px; height: 11px; border-radius: 999px; border: 2px solid rgba(219, 234, 254, 0.45); border-top-color: #dbeafe; display: none; animation: spin-360 0.8s linear infinite; }
-.dashboard-project #generate-context-btn.is-loading .btn-spinner { display: inline-block; }
-.dashboard-project .context-panel .context-body { padding: 0 12px 12px; }
-.dashboard-project .context-content { line-height: 1.45; }
-.dashboard-project .context-empty { color: var(--color-muted); font-size: var(--text-xs); }
+.dashboard-project .project-action-btn { min-width: 120px; display: inline-flex; align-items: center; justify-content: center; }
 .dashboard-project .legend-strip { display: flex; flex-wrap: wrap; gap: 12px; margin: 0 0 12px; padding: 10px 12px; border: 1px solid var(--color-border); border-radius: 12px; background: rgba(255, 255, 255, 0.02); }
 .dashboard-project .legend-item { display: inline-flex; align-items: center; gap: 6px; font-size: var(--text-xs); color: var(--color-muted); }
 .dashboard-project .legend-dot { width: 8px; height: 8px; border-radius: 999px; }
@@ -529,9 +517,9 @@ code, pre, .mono { font-family: var(--font-mono); font-size: var(--text-sm); }
 .dashboard-project .progress-meta { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; color: var(--color-muted); font-family: var(--font-mono); font-size: var(--text-sm); }
 .dashboard-project .mini-progress { height: 5px; border-radius: 999px; background: var(--color-bg-alt); overflow: hidden; border: 1px solid var(--color-border); }
 .dashboard-project .mini-progress-value { height: 100%; background: linear-gradient(90deg, #3b82f6, #22c55e); width: var(--progress, 0%); }
-.dashboard-project .filters { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-bottom: 16px; }
-.dashboard-project .filters select { width: 100%; background: var(--color-panel-soft); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 10px; padding: 8px 10px; font-size: var(--text-xs); }
-.dashboard-project .filter-actions { grid-column: 1 / -1; display: flex; gap: 8px; }
+.dashboard-project .filters { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+.dashboard-project .filters select { flex: 0 0 160px; width: 160px; background: var(--color-panel-soft); border: 1px solid var(--color-border); color: var(--color-text); border-radius: 10px; padding: 8px 10px; font-size: var(--text-xs); }
+.dashboard-project .filter-actions { display: flex; gap: 8px; }
 .dashboard-project .btn-chain-start { background: rgba(34, 197, 94, 0.2); color: #dcfce7; border-color: rgba(34, 197, 94, 0.45); }
 .dashboard-project .btn-chain-stop { background: rgba(239, 68, 68, 0.16); color: #fecaca; border-color: rgba(239, 68, 68, 0.35); }
 .dashboard-project .btn:disabled { opacity: 0.45; cursor: not-allowed; }
@@ -621,7 +609,9 @@ code, pre, .mono { font-family: var(--font-mono); font-size: var(--text-sm); }
   .dashboard-project .page { width: min(620px, 94vw); }
   .dashboard-project .topbar { flex-direction: column; align-items: flex-start; }
   .dashboard-project .project-title-row { align-items: stretch; flex-direction: column; }
-  .dashboard-project .filters { grid-template-columns: 1fr; }
+  .dashboard-project .filters { align-items: stretch; }
+  .dashboard-project .filters select { flex-basis: 100%; width: 100%; }
+  .dashboard-project .filter-actions { margin-left: 0; width: 100%; }
   .dashboard-project .kanban-grid { grid-template-columns: 1fr; }
 }
 

--- a/agentplan/dashboard/templates/activity.html
+++ b/agentplan/dashboard/templates/activity.html
@@ -6,8 +6,6 @@
 
 {% block content %}
 <section class="activity-shell">
-  <div id="agent-filters" class="filters-row"></div>
-  <div id="action-filters" class="filters-row"></div>
   <p id="presence-line" class="presence-line" hidden></p>
   <div id="feed" class="feed"></div>
 </section>
@@ -16,8 +14,7 @@
 {% block scripts %}
 <script>
   const FEED_LIMIT = 300;
-  const ACTION_OPTIONS = ["all", "created", "started", "done", "blocked", "skipped", "log"];
-  const feedState = { events: [], activeAgent: "all", activeAction: "all" };
+  const feedState = { events: [] };
 
   function esc(v) {
     return String(v ?? "").replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
@@ -58,42 +55,6 @@
     line.hidden = false;
     const parts = presence.map((a) => `${esc(a.name)} (${esc(relativeTime(a.last_seen))})`);
     line.innerHTML = `Active agents ${parts.join(" · ")}`;
-  }
-
-  function renderAgentFilters(events) {
-    const wrap = document.getElementById("agent-filters");
-    const agents = [...new Set((events || []).map((e) => e.agent || "system"))].sort();
-    const options = ["all", ...agents];
-    wrap.innerHTML = "";
-    options.forEach((agent) => {
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = `filter-pill${feedState.activeAgent === agent ? " active" : ""}`;
-      btn.textContent = agent === "all" ? "All" : agent;
-      btn.addEventListener("click", () => {
-        feedState.activeAgent = agent;
-        renderAgentFilters(events);
-        renderFeed();
-      });
-      wrap.appendChild(btn);
-    });
-  }
-
-  function renderActionFilters() {
-    const wrap = document.getElementById("action-filters");
-    wrap.innerHTML = "";
-    ACTION_OPTIONS.forEach((action) => {
-      const btn = document.createElement("button");
-      btn.type = "button";
-      btn.className = `filter-pill${feedState.activeAction === action ? " active" : ""}`;
-      btn.textContent = action === "all" ? "All" : action;
-      btn.addEventListener("click", () => {
-        feedState.activeAction = action;
-        renderActionFilters();
-        renderFeed();
-      });
-      wrap.appendChild(btn);
-    });
   }
 
   function collapseCreated(rows) {
@@ -162,10 +123,7 @@
     const pinnedBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 28;
     container.innerHTML = "";
 
-    let rows = feedState.events.slice();
-    rows = rows.filter((item) => feedState.activeAgent === "all" || (item.agent || "system") === feedState.activeAgent);
-    rows = rows.filter((item) => feedState.activeAction === "all" || (item.action_type || "other") === feedState.activeAction);
-    rows = collapseCreated(rows);
+    const rows = collapseCreated(feedState.events.slice());
 
     let lastDay = "";
     rows.forEach((item) => {
@@ -188,8 +146,6 @@
 
   function applyActivity(payload) {
     feedState.events = (payload.events || []).slice(-FEED_LIMIT);
-    renderAgentFilters(feedState.events);
-    renderActionFilters();
     renderPresence(payload.active_agents || []);
     renderFeed();
   }

--- a/agentplan/dashboard/templates/project.html
+++ b/agentplan/dashboard/templates/project.html
@@ -59,7 +59,7 @@
   {%- endif -%}
   </span>
   <input id="project-dir-input" class="project-dir-input" name="directory" type="text" value="{{ project.dir or '' }}" placeholder="~/path/to/repo" hidden>
-  <button id="project-dir-edit-btn" class="btn btn-sm" type="button">Edit</button>
+  <button id="project-dir-edit-btn" class="btn btn-sm btn-secondary" type="button">Edit</button>
   <button id="project-dir-save-btn" class="btn btn-sm btn-primary" type="button" hidden>Save</button>
   <button id="project-dir-cancel-btn" class="btn btn-sm" type="button" hidden>Cancel</button>
 </div>
@@ -74,7 +74,7 @@
 
 <div class="project-meta">
   <span>{{ done_count }}/{{ total_count }} done</span>
-  <button id="add-ticket-btn" class="btn btn-primary btn-sm" type="button">+ Add Ticket</button>
+  <button id="add-ticket-btn" class="btn btn-primary project-action-btn" type="button">+ Add Ticket</button>
 </div>
 
 <dialog id="add-ticket-dialog" class="ticket-dialog">
@@ -126,30 +126,7 @@
   </form>
 </dialog>
 
-<details class="context-panel" aria-label="project context">
-  <summary>
-    <span>Project Context</span>
-    <button id="generate-context-btn" class="btn btn-sm btn-primary" type="button">
-      <span class="btn-label">Generate Repo Context</span>
-      <span class="btn-spinner" aria-hidden="true"></span>
-    </button>
-  </summary>
-  <div class="context-body">
-  {% if context_payload.exists %}
-  <div class="context-content">{{ context_payload.html|safe }}</div>
-  {% else %}
-  <div class="context-empty">No context file yet. The first agent to work on this project will create one.</div>
-  {% endif %}
-  </div>
-</details>
-
 <form method="get" class="filters" aria-label="filters">
-  <select name="status" aria-label="Status filter">
-    <option value="" {{ "selected" if not filters.status else "" }}>All statuses</option>
-    {% for status in ["pending", "in-progress", "blocked", "needs-review", "failed", "done"] %}
-    <option value="{{ status }}" {{ "selected" if filters.status == status else "" }}>{{ status }}</option>
-    {% endfor %}
-  </select>
   <select name="priority" aria-label="Priority filter">
     <option value="" {{ "selected" if not filters.priority else "" }}>All priorities</option>
     {% for priority in ["high", "medium", "low", "none"] %}
@@ -163,8 +140,8 @@
     {% endfor %}
   </select>
   <div class="filter-actions">
-    <button class="btn btn-primary" type="submit">Apply filters</button>
-    <a class="btn" href="{{ url_for('project_detail', slug=project.slug) }}">Reset</a>
+    <button class="btn btn-sm btn-primary" type="submit">Apply filters</button>
+    <a class="btn btn-sm btn-secondary" href="{{ url_for('project_detail', slug=project.slug) }}">Reset</a>
   </div>
 </form>
 

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -1622,11 +1622,10 @@ def test_dashboard_project_board_marks_ticket_cards_draggable_using_real_status(
 
 
 
-def test_dashboard_project_detail_shows_linked_directory_and_context_content():
+def test_dashboard_project_detail_shows_linked_directory():
     from agentplan.dashboard import app
 
     os.makedirs("/tmp/web-context", exist_ok=True)
-    Path("/tmp/web-context/.agentplan.md").write_text("# Context\n- Run tests", encoding="utf-8")
     cli("create", "Web Context", "--dir", "/tmp/web-context")
 
     client = app.test_client()
@@ -1634,11 +1633,9 @@ def test_dashboard_project_detail_shows_linked_directory_and_context_content():
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "/tmp/web-context" in body
-    assert "Project Context" in body
-    assert "Run tests" in body
 
 
-def test_dashboard_project_detail_shows_no_directory_and_no_context_message():
+def test_dashboard_project_detail_shows_no_directory_message():
     from agentplan.dashboard import app
 
     cli("create", "Web No Context")
@@ -1647,7 +1644,6 @@ def test_dashboard_project_detail_shows_no_directory_and_no_context_message():
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "No directory set" in body
-    assert "No context file yet. The first agent to work on this project will create one." in body
 
 
 def test_dashboard_project_detail_includes_editable_directory_field():
@@ -1661,6 +1657,21 @@ def test_dashboard_project_detail_includes_editable_directory_field():
     body = resp.get_data(as_text=True)
     assert 'id="project-dir-edit-btn"' in body
     assert 'id="project-dir-input"' in body
+
+
+def test_dashboard_project_detail_does_not_render_status_filter():
+    from agentplan.dashboard import app
+
+    cli("create", "Web No Status Filter")
+
+    client = app.test_client()
+    resp = client.get("/project/web-no-status-filter")
+    assert resp.status_code == 200
+    body = resp.get_data(as_text=True)
+    assert 'name="status"' not in body
+    assert "All statuses" not in body
+    assert 'name="priority"' in body
+    assert 'name="tag"' in body
 
 
 def test_dashboard_project_detail_includes_ticket_field_edit_dialog():
@@ -2360,6 +2371,8 @@ def test_dashboard_activity_page_returns_html():
     assert resp.status_code == 200
     body = resp.get_data(as_text=True)
     assert "<html" in body.lower() or "<!doctype" in body.lower()
+    assert 'id="agent-filters"' not in body
+    assert 'id="action-filters"' not in body
 
 
 def test_dashboard_agents_page_supports_crud_and_detected_tools():
@@ -3512,18 +3525,18 @@ def test_dashboard_priority_filter_string_labels():
     none_ticket = {"priority": "none", "status": "pending", "tags": ""}
 
     # String label filters must match
-    assert _ticket_matches(high_ticket, "", "high", "") is True
-    assert _ticket_matches(medium_ticket, "", "medium", "") is True
-    assert _ticket_matches(low_ticket, "", "low", "") is True
-    assert _ticket_matches(none_ticket, "", "none", "") is True
+    assert _ticket_matches(high_ticket, "high", "") is True
+    assert _ticket_matches(medium_ticket, "medium", "") is True
+    assert _ticket_matches(low_ticket, "low", "") is True
+    assert _ticket_matches(none_ticket, "none", "") is True
 
     # Non-matching priority must not match
-    assert _ticket_matches(high_ticket, "", "low", "") is False
-    assert _ticket_matches(low_ticket, "", "high", "") is False
+    assert _ticket_matches(high_ticket, "low", "") is False
+    assert _ticket_matches(low_ticket, "high", "") is False
 
     # Numeric values (old bug) must NOT accidentally match string priorities
-    assert _ticket_matches(high_ticket, "", "1", "") is False
-    assert _ticket_matches(medium_ticket, "", "3", "") is False
+    assert _ticket_matches(high_ticket, "1", "") is False
+    assert _ticket_matches(medium_ticket, "3", "") is False
 
 
 def test_dashboard_priority_filter_via_api():


### PR DESCRIPTION
This change simplifies two dashboard surfaces that had accumulated filtering and context UI that no longer matches how the app is used.

On the project details page, the old project context section was removed entirely, along with its backend markdown rendering and client-side context generation polling. The page now keeps only the controls that still matter for day-to-day ticket management. The status filter was removed because the kanban board already segments tickets by status, which made the extra filter redundant and easy to misuse. The remaining priority and tag filters were tightened up visually, with smaller action buttons aligned directly next to the dropdowns. As part of the same cleanup, the dashboard now has an explicit reusable secondary button class, and the project directory Edit button plus the filter Reset action were moved onto that shared styling.

On the activity page, the log filter pills were removed from the UI and their client-side state/rendering logic was deleted. The activity feed still renders and updates live through SSE, but it now presents the stream directly without the extra filter controls.

The user-facing effect is a less cluttered dashboard with fewer duplicate controls and more consistent button styling. The code-level root cause was that several older dashboard affordances were still wired through templates, CSS, and JavaScript even after the main workflows had moved elsewhere. This change removes that dead or redundant plumbing instead of leaving hidden support paths in place.

Validation was done with targeted dashboard regression tests:

- `pytest -q test_agentplan.py -k "dashboard_project_detail_shows_linked_directory or dashboard_project_detail_shows_no_directory_message or dashboard_project_detail_includes_editable_directory_field or dashboard_project_detail_does_not_render_status_filter or dashboard_project_board_marks_ticket_cards_draggable_using_real_status or dashboard_priority_filter_string_labels or dashboard_priority_filter_via_api or dashboard_activity_page_returns_html"`
