### PR TITLE
refactor: consolidate tool detection logic into shared function

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -86,20 +86,41 @@ TERMINAL_CHOICES = {"auto", "iterm2", "terminal"}
 LOGGER = logging.getLogger(__name__)
 
 
-def _detect_installed_tools():
-    installed = []
-    for tool in AUTO_DETECT_TOOL_COMMANDS:
+def _detect_tool_status(tools=None):
+    """Detect which tools are installed and return status dict.
+    
+    Args:
+        tools: Optional list of tool names. If None, uses AUTO_DETECT_TOOL_COMMANDS keys.
+    
+    Returns:
+        List of dicts with 'name' and 'found' keys.
+    """
+    if tools is None:
+        tools = list(AUTO_DETECT_TOOL_COMMANDS.keys())
+    
+    detected = []
+    for tool in tools:
+        found = False
         try:
             result = subprocess.run(
                 ["which", tool],
                 capture_output=True,
                 text=True,
             )
+            found = result.returncode == 0
         except Exception:
-            continue
-        if result.returncode == 0:
-            installed.append(tool)
-    return installed
+            found = False
+        detected.append({"name": tool, "found": found})
+    return detected
+
+
+def _detect_installed_tools():
+    """Detect which tools are installed and return list of names.
+    
+    Returns:
+        List of tool names that are installed.
+    """
+    return [item["name"] for item in _detect_tool_status() if item["found"]]
 
 
 def _create_default_agents(conn, tools):

--- a/agentplan/dashboard/routes.py
+++ b/agentplan/dashboard/routes.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 from flask import Flask, abort, redirect, render_template, request, url_for
 from werkzeug.utils import secure_filename
 
-from agentplan.cli import slugify, spawn_terminal
+from agentplan.cli import slugify, spawn_terminal, _detect_tool_status
 from agentplan.db import (
     check_auto_complete,
     create_agent,
@@ -122,17 +122,9 @@ def _require_local_origin(fn):
 
 
 def _detect_tools_status():
+    """Detect which tools are installed. Uses shared implementation from cli module."""
     tools = ["claude", "codex", "aider", "cursor", "openclaw"]
-    detected = []
-    for tool in tools:
-        found = False
-        try:
-            result = subprocess.run(["which", tool], capture_output=True, text=True)
-            found = result.returncode == 0
-        except Exception:
-            found = False
-        detected.append({"name": tool, "found": found})
-    return detected
+    return _detect_tool_status(tools=tools)
 
 
 def _parse_roles_from_form(form):


### PR DESCRIPTION
## Problem
Tool detection logic was duplicated:
- `_detect_installed_tools()` in cli.py returned a list of tool names
- `_detect_tools_status()` in dashboard/routes.py returned a list of dicts with name and found status

## Solution
- Created `_detect_tool_status(tools=None)` in cli.py that returns detailed status info
- `_detect_installed_tools()` now uses the shared function internally
- `_detect_tools_status()` in routes.py now delegates to the shared function

## Benefits
- DRY principle: single source of truth for tool detection logic
- Easier to maintain: changes to detection logic only need to be made in one place
- Cleaner code: routes.py no longer has subprocess logic for tool detection

## Testing
All 305 existing tests pass.