### PR TITLE
fix: normalize linked project directory paths

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -142,6 +142,15 @@ def _validate_timeout_sec(timeout, flag_name="--timeout"):
     return int(timeout)
 
 
+def _normalize_project_dir(path_value):
+    if path_value is None:
+        return None
+    path_value = str(path_value).strip()
+    if not path_value:
+        return None
+    return os.path.abspath(os.path.expanduser(path_value))
+
+
 def _effective_ticket_timeout_sec(project, ticket, override_timeout=None):
     if override_timeout is not None:
         return override_timeout
@@ -1736,11 +1745,12 @@ def cmd_create(args):
         conn.close()
         fail(f"Space '{space_slug}' does not exist.")
     space_id = space_row[0]
+    project_dir = _normalize_project_dir(getattr(args, "dir", None))
     
     slug = unique_slug(conn, slugify(args.title))
     conn.execute(
         "INSERT INTO projects (slug, title, notes, dir, timeout_sec, space_id) VALUES (?,?,?,?,?,?)",
-        (slug, args.title, args.notes, args.dir, timeout_sec, space_id),
+        (slug, args.title, args.notes, project_dir, timeout_sec, space_id),
     )
     pid = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
     n = 0
@@ -1779,7 +1789,7 @@ def cmd_project(args):
     
     # Handle --dir flag
     if dir_path:
-        resolved_dir = os.path.expanduser(dir_path)
+        resolved_dir = _normalize_project_dir(dir_path)
         if not os.path.exists(resolved_dir):
             print(f"Warning: directory does not exist on disk: {resolved_dir}")
         updates.append("dir=?")

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -247,6 +247,29 @@ def test_project_command_sets_and_updates_directory():
     assert row["dir"] == "/tmp/project-dir-cmd-b"
 
 
+def test_project_directory_commands_normalize_relative_paths(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    updated_dir = tmp_path / "updated"
+    updated_dir.mkdir()
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        cli("create", "Relative Dir Project", "--dir", "repo")
+        conn = agentplan.get_connection("/tmp/test_agentplan.db")
+        created_row = conn.execute("SELECT dir FROM projects WHERE slug='relative-dir-project'").fetchone()
+        conn.close()
+        assert created_row["dir"] == str(repo_dir)
+        cli("project", "relative-dir-project", "--dir", "updated")
+    finally:
+        os.chdir(original_cwd)
+
+    conn = agentplan.get_connection("/tmp/test_agentplan.db")
+    row = conn.execute("SELECT dir FROM projects WHERE slug='relative-dir-project'").fetchone()
+    conn.close()
+    assert row["dir"] == str(updated_dir)
+
+
 def test_list_projects_after_create():
     cli("create", "Alpha Project")
     out, err, code = cli("list")
@@ -5085,4 +5108,3 @@ def test_doc_remove_nonexistent_fails():
     cli("space", "create", "remove-fail-space")
     out, err, code = cli("doc", "remove", "remove-fail-space", "nonexistent.md", "--force")
     assert code == 2
-


### PR DESCRIPTION
## Summary
- normalize project --dir values to expanded absolute paths when creating or updating a project
- keep linked directories stable across later commands that reuse the stored path as a working directory
- add a regression test covering relative directory values for both create and update flows

## Testing
- python3 -m pytest test_agentplan.py -x -q