### PR TITLE
fix: handle invalid GitHub issue import payloads

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -4030,6 +4030,9 @@ def cmd_issue_import(args):
     except urllib.error.URLError as exc:
         conn.close()
         fail(f"GitHub API request failed: {exc.reason}.")
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        conn.close()
+        fail("GitHub API returned malformed JSON or non-UTF-8 data.")
 
     imported = 0
     updated = 0

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -4358,6 +4358,28 @@ def test_issue_import_is_idempotent_and_updates_existing_ticket():
     assert rows[0]["title"] == "New title"
 
 
+@pytest.mark.parametrize("payload", [b"{not json", b"\xff\xfe"])
+def test_issue_import_handles_invalid_github_api_payload(payload):
+    cli("create", "Issue Import Bad Payload")
+
+    class FakeResp:
+        def read(self):
+            return payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    with patch("agentplan.cli.urllib.request.urlopen", return_value=FakeResp()):
+        out, err, code = cli("issue", "import", "issue-import-bad-payload", "--repo", "acme/repo", "--token", "tkn")
+
+    assert code == 2
+    assert out == ""
+    assert "GitHub API returned malformed JSON or non-UTF-8 data." in err
+
+
 def test_pr_automate_dry_run_prints_schema():
     os.makedirs("/tmp/pr-auto-dry", exist_ok=True)
     cli("create", "PR Auto Dry", "--dir", "/tmp/pr-auto-dry")
@@ -5085,4 +5107,3 @@ def test_doc_remove_nonexistent_fails():
     cli("space", "create", "remove-fail-space")
     out, err, code = cli("doc", "remove", "remove-fail-space", "nonexistent.md", "--force")
     assert code == 2
-


### PR DESCRIPTION
## Summary
- handle malformed JSON and non-UTF-8 GitHub API responses during `agentplan issue import`
- fail with a user-friendly CLI message instead of surfacing an uncaught exception
- add regression coverage for both malformed JSON bytes and invalid UTF-8 bytes

## Testing
- python3 -m pytest test_agentplan.py -x -q