### PR TITLE
refactor: reuse shared timeout validation in claim

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -2738,9 +2738,7 @@ def _claim_next_ticket(conn, project_id, started_by=None, tag=None):
 def cmd_claim(args):
     """Atomically claim the next unblocked ticket in a project for an agent."""
     _validate_len(getattr(args, "agent", None), MAX_AGENT_LEN, "Agent name")
-    timeout = getattr(args, "timeout", None)
-    if timeout is not None and timeout <= 0:
-        fail("--timeout must be a positive integer")
+    timeout = _validate_timeout_sec(getattr(args, "timeout", None))
 
     conn = _ensure(get_connection())
     proj = resolve_project(conn, args.project)


### PR DESCRIPTION
## Summary
- replace cmd_claim's inline --timeout check with the shared _validate_timeout_sec() helper
- keep claim timeout validation behavior consistent with the other timeout-aware commands
- avoid duplicate validation logic in the CLI

## Testing
- python3 -m pytest test_agentplan.py -x -q