### PR TITLE
fix: hide internal completion command from help

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -4583,7 +4583,7 @@ def build_parser():
     cp = sub.add_parser("completion", help="Print shell completion script")
     cp.add_argument("shell", choices=COMPLETION_SHELLS)
 
-    internal = sub.add_parser("__complete", help=argparse.SUPPRESS)
+    internal = _add_deprecated_parser(sub, "__complete", help=argparse.SUPPRESS)
     internal.add_argument("shell", choices=COMPLETION_SHELLS, help=argparse.SUPPRESS)
     internal.add_argument("current", help=argparse.SUPPRESS)
     internal.add_argument("words", nargs="*", help=argparse.SUPPRESS)

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -79,6 +79,14 @@ def test_help_exits_zero():
     assert code == 0
 
 
+def test_help_hides_internal_complete_command():
+    out, err, code = cli("--help")
+    assert code == 0
+    assert err == ""
+    assert "__complete" not in out
+    assert "==SUPPRESS==" not in out
+
+
 def test_issue_and_artifact_help_exits_zero():
     out_issue, err_issue, code_issue = cli("issue", "--help")
     assert code_issue == 0


### PR DESCRIPTION
## Summary
- hide the internal `__complete` subcommand from top-level help output
- add a regression test that asserts `agentplan --help` no longer leaks internal completion plumbing or `==SUPPRESS==`

## Why
The CLI exposed an internal completion helper in user-facing help text, which made the command list noisy and confusing.

## Testing
- python3 -m pytest test_agentplan.py -x -q
