### PR TITLE
fix: allow none priority on ticket add

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -4353,7 +4353,7 @@ def build_parser():
     a = ts.add_parser("add")
     a.add_argument("project"); a.add_argument("title"); a.add_argument("--desc"); a.add_argument("--depends"); a.add_argument("--notes")
     a.add_argument("--tag", help="Comma-separated tags (e.g. security,css)")
-    a.add_argument("--priority", choices=PRIORITY_CHOICES[:-1], default="none")
+    a.add_argument("--priority", choices=PRIORITY_CHOICES, default="none")
     a.add_argument("--due", help="Due date in YYYY-MM-DD format")
     a.add_argument("--timeout", type=int, help="Per-ticket timeout in seconds")
     a.add_argument("--role", help="Assign a registered role to this ticket (must exist in role registry)")

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -561,6 +561,17 @@ def test_add_ticket_priority_persisted():
     assert row["priority"] == "high"
 
 
+def test_add_ticket_accepts_explicit_none_priority():
+    cli("create", "No Priority Project")
+    out, err, code = cli("ticket", "add", "no-priority-project", "Backlog item", "--priority", "none")
+    assert code == 0, err
+    assert "priority: none" in out.lower()
+    conn = agentplan.get_connection("/tmp/test_agentplan.db")
+    row = conn.execute("SELECT priority FROM tickets WHERE project_id=1 AND num=1").fetchone()
+    conn.close()
+    assert row["priority"] == "none"
+
+
 def test_add_ticket_tags_persisted():
     cli("create", "Tag Project")
     out, err, code = cli("ticket", "add", "tag-project", "Harden auth", "--tag", "security,css")


### PR DESCRIPTION
## Summary
- allow `agentplan ticket add --priority none` to pass parser validation
- keep parser choices aligned with the command default value
- add regression coverage for explicitly creating backlog tickets with `none` priority

## Testing
- python3 -m pytest test_agentplan.py -x -q
