### PR TITLE
fix: handle git diff failures in pr automation

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -4178,8 +4178,13 @@ def cmd_pr_automate(args):
     if add.returncode != 0:
         fail(f"git add failed: {(add.stderr or add.stdout or '').strip()}")
 
-    staged_check = _run_cmd(commands[2], cwd=project_dir, capture_output=False)
-    has_staged_changes = staged_check.returncode != 0
+    staged_check = _run_cmd(commands[2], cwd=project_dir)
+    if staged_check.returncode == 0:
+        has_staged_changes = False
+    elif staged_check.returncode == 1:
+        has_staged_changes = True
+    else:
+        fail(f"git diff --cached failed: {(staged_check.stderr or staged_check.stdout or '').strip()}")
     if has_staged_changes:
         commit = _run_cmd(["git", "commit", "-m", commit_msg], cwd=project_dir)
         if commit.returncode != 0:

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -4397,6 +4397,25 @@ def test_pr_automate_creates_pr_when_none_exists():
     assert any(cmd[:3] == ["gh", "pr", "create"] for cmd in calls)
 
 
+def test_pr_automate_surfaces_git_diff_errors():
+    os.makedirs("/tmp/pr-auto-diff-error", exist_ok=True)
+    cli("create", "PR Auto Diff Error", "--dir", "/tmp/pr-auto-diff-error")
+    cli("ticket", "add", "pr-auto-diff-error", "Add guardrails")
+
+    def fake_run(argv, cwd=None, capture_output=True, text=True):
+        if argv[:3] == ["git", "diff", "--cached"]:
+            return type("R", (), {"returncode": 128, "stdout": "", "stderr": "fatal: not a git repository"})()
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("agentplan.cli.shutil.which", return_value="/usr/bin/fake"), \
+         patch("agentplan.cli.subprocess.run", side_effect=fake_run):
+        out, err, code = cli("pr", "automate", "pr-auto-diff-error", "--ticket-id", "1")
+
+    assert out == ""
+    assert code == 2
+    assert "git diff --cached failed: fatal: not a git repository" in err
+
+
 def test_artifact_verify_detects_tampering():
     os.makedirs("/tmp/artifact-verify", exist_ok=True)
     cli("create", "Artifact Verify", "--dir", "/tmp/artifact-verify")


### PR DESCRIPTION
## Summary
- distinguish between "changes staged" (`git diff --cached --quiet` exit code 1) and actual git errors
- fail fast with the underlying git error instead of pretending changes exist and falling through to a commit failure
- add regression coverage for the error path

## Testing
- python3 -m pytest test_agentplan.py -x -q
- python3 -m pytest test_marketplace_actions.py -q