### PR TITLE
fix: validate search space filters

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -3224,6 +3224,13 @@ def cmd_search(args):
         conn.close()
         fail("Search query cannot be empty.", suggestions=["Run `agentplan search <text>` with a keyword."])
 
+    space_slug = (getattr(args, "space", None) or "").strip()
+    if space_slug:
+        space_row = conn.execute("SELECT id FROM spaces WHERE slug=?", (space_slug,)).fetchone()
+        if not space_row:
+            conn.close()
+            fail(f"Space '{space_slug}' not found.", suggestions=["Create it first with: agentplan space create <slug>"])
+
     query_lower = query.lower()
     like = f"%{query_lower}%"
     

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -4711,6 +4711,14 @@ def test_search_space_flag_filters_docs_by_space():
     # No tickets shown since projects aren't associated with spaces
 
 
+def test_search_unknown_space_fails_helpfully():
+    out, err, code = cli("search", "database", "--space", "missing-space")
+    assert code == 2
+    assert out == ""
+    assert "Space 'missing-space' not found." in err
+    assert "Create it first with: agentplan space create <slug>" in err
+
+
 def test_search_doc_content_is_searched_not_just_filename():
     """Search should find text in doc content, not just filenames."""
     cli("space", "create", "content-search-space")


### PR DESCRIPTION
## Summary
- validate `agentplan search --space [space-slug]` against registered spaces before scanning docs or tickets
- return the same helpful error style used by other space-aware commands when the slug is missing
- add a regression test for the unknown-space path

## Testing
- python3 -m pytest test_agentplan.py -x -q