### PR TITLE
fix: clarify duplicate role errors

### DIFF
--- a/agentplan/cli.py
+++ b/agentplan/cli.py
@@ -3854,10 +3854,13 @@ def cmd_role_add(args):
     conn = _ensure(get_connection())
     try:
         role = db_create_role(conn, args.name, args.description)
-        print(f"Added role '{role.name}'.")
+    except sqlite3.IntegrityError:
+        conn.close()
+        raise CliError(f"Role '{args.name}' already exists.")
     except Exception as e:
         conn.close()
         fail(f"Could not add role '{args.name}': {e}")
+    print(f"Added role '{role.name}'.")
     conn.close()
 
 
@@ -3878,12 +3881,17 @@ def cmd_role_update(args):
             suggestions=["Use at least one of: `--name`, `--description`."],
         )
     conn = _ensure(get_connection())
-    role = db_update_role(
-        conn,
-        args.name,
-        new_name=args.new_name,
-        new_description=args.description,
-    )
+    try:
+        role = db_update_role(
+            conn,
+            args.name,
+            new_name=args.new_name,
+            new_description=args.description,
+        )
+    except sqlite3.IntegrityError:
+        conn.close()
+        conflict_name = args.new_name or args.name
+        raise CliError(f"Role '{conflict_name}' already exists.")
     if not role:
         conn.close()
         fail(f"Role '{args.name}' not found.")

--- a/test_agentplan.py
+++ b/test_agentplan.py
@@ -2756,7 +2756,7 @@ def test_role_add_list_remove_round_trip():
     assert "No roles found." in out
 
 
-def test_role_add_duplicate_name_fails_gracefully():
+def test_role_add_duplicate_name_reports_clear_error():
     out1, err1, code1 = cli("role", "add", "qa")
     assert code1 == 0, err1
     assert "Added role 'qa'." in out1
@@ -2764,8 +2764,19 @@ def test_role_add_duplicate_name_fails_gracefully():
     out2, err2, code2 = cli("role", "add", "qa")
     assert code2 == 2
     assert out2 == ""
-    assert "Could not add role 'qa'" in err2
-    assert "UNIQUE constraint failed" in err2
+    assert "Role 'qa' already exists." in err2
+    assert "UNIQUE constraint failed" not in err2
+
+
+def test_role_update_rename_to_existing_conflict_reports_clear_error():
+    cli("role", "add", "backend")
+    cli("role", "add", "frontend")
+
+    out, err, code = cli("role", "update", "backend", "--name", "frontend")
+    assert code == 2
+    assert out == ""
+    assert "Role 'frontend' already exists." in err
+    assert "UNIQUE constraint failed" not in err
 
 
 def test_ticket_add_rejects_undefined_prefixed_role_tag():


### PR DESCRIPTION
## Summary
- catch duplicate-role conflicts in `cmd_role_add` and `cmd_role_update`
- return consistent `CliError` messages instead of leaking raw SQLite constraint text
- add regression coverage for duplicate adds and rename conflicts

## Testing
- python3 -m pytest test_agentplan.py -x -q